### PR TITLE
Improve tweak interaction and refresh project README

### DIFF
--- a/Infern0/SettingsViewController.h
+++ b/Infern0/SettingsViewController.h
@@ -98,6 +98,8 @@ extern NSString * const kSettingsFakeClockUpSpeed;
 extern NSString * const kSettingsPancakeEnabled;
 extern NSString * const kSettingsCylinderLiteEnabled;
 extern NSString * const kSettingsBarmojiEnabled;
+extern NSString * const kSettingsRoundedIconsEnabled;
+extern NSString * const kSettingsWatchLayoutEnabled;
 extern NSString * const kSettingsBlurryBadgesEnabled;
 extern NSString * const kSettingsSnapperEnabled;
 extern NSString * const kSettingsPullOverEnabled;

--- a/Infern0/SettingsViewController.m
+++ b/Infern0/SettingsViewController.m
@@ -1047,6 +1047,11 @@ static NSString * const kSettingsBarmojiYOffset = @"BarmojiYOffset";
 static NSString * const kSettingsBarmojiWidthPct = @"BarmojiWidthPct";
 static NSString * const kSettingsBarmojiFontSize = @"BarmojiFontSize";
 static NSString * const kSettingsBarmojiBackgroundAlphaPct = @"BarmojiBackgroundAlphaPct";
+NSString * const kSettingsRoundedIconsEnabled = @"RoundedIconsEnabled";
+static NSString * const kSettingsRoundedIconsRadius = @"RoundedIconsRadius";
+NSString * const kSettingsWatchLayoutEnabled = @"WatchLayoutEnabled";
+static NSString * const kSettingsWatchLayoutCompactPct = @"WatchLayoutCompactPct";
+static NSString * const kSettingsWatchLayoutScalePct = @"WatchLayoutScalePct";
 NSString * const kSettingsBlurryBadgesEnabled = @"BlurryBadgesEnabled";
 static NSString * const kSettingsBlurryBadgesRed = @"BlurryBadgesRed";
 static NSString * const kSettingsBlurryBadgesGreen = @"BlurryBadgesGreen";
@@ -1172,6 +1177,8 @@ static volatile int g_notificationisland_live_running = 0;
 static volatile int g_notificationisland_live_stop_requested = 0;
 static volatile int g_velvet_live_running = 0;
 static volatile int g_velvet_live_stop_requested = 0;
+static volatile int g_visual_refresh_live_running = 0;
+static volatile int g_visual_refresh_live_stop_requested = 0;
 static volatile int g_gravitylite_background_armed = 0;
 static volatile int g_gravitylite_start_worker_running = 0;
 static volatile int g_gravity_motion_stop_requested = 1;
@@ -1288,6 +1295,7 @@ static void settings_request_typebanner_stop(void) { g_typebanner_live_stop_requ
 static void settings_request_notificationisland_stop(void) { g_notificationisland_live_stop_requested = 1; }
 static void settings_request_themer_stop(void) { g_themer_live_stop_requested = 1; }
 static void settings_request_velvet_stop(void) { g_velvet_live_stop_requested = 1; }
+static void settings_request_visual_refresh_stop(void) { g_visual_refresh_live_stop_requested = 1; }
 static void settings_request_gravitylite_stop(void)
 {
     __sync_lock_test_and_set(&g_gravitylite_background_armed, 0);
@@ -1559,6 +1567,18 @@ static bool settings_stop_barmoji_registered(BOOL springboardWillDie)
     return barmoji_stop_in_session();
 }
 
+static bool settings_stop_roundedicons_registered(BOOL springboardWillDie)
+{
+    (void)springboardWillDie;
+    return roundedicons_stop_in_session();
+}
+
+static bool settings_stop_watchlayout_registered(BOOL springboardWillDie)
+{
+    (void)springboardWillDie;
+    return watchlayout_stop_in_session();
+}
+
 static bool settings_stop_blurrybadges_registered(BOOL springboardWillDie)
 {
     (void)springboardWillDie;
@@ -1649,6 +1669,8 @@ static void settings_each_springboard_cleanup_entry(void (^block)(const Settings
         { kSettingsPancakeEnabled, "Pancake", NULL, settings_stop_pancake_registered, pancake_forget_remote_state, NULL, YES, YES },
         { kSettingsCylinderLiteEnabled, "Cylinder Lite", NULL, settings_stop_cylinderlite_registered, cylinderlite_forget_remote_state, NULL, YES, YES },
         { kSettingsBarmojiEnabled, "Barmoji", NULL, settings_stop_barmoji_registered, barmoji_forget_remote_state, NULL, YES, YES },
+        { kSettingsRoundedIconsEnabled, "Rounded Icons", NULL, settings_stop_roundedicons_registered, roundedicons_forget_remote_state, NULL, YES, YES },
+        { kSettingsWatchLayoutEnabled, "Watch Layout", NULL, settings_stop_watchlayout_registered, watchlayout_forget_remote_state, NULL, YES, YES },
         { kSettingsBlurryBadgesEnabled, "BlurryBadges", NULL, settings_stop_blurrybadges_registered, blurrybadges_forget_remote_state, NULL, YES, YES },
         { kSettingsSnapperEnabled, "Snapper", NULL, settings_stop_snapper_registered, snapper_forget_remote_state, NULL, YES, YES },
         { kSettingsPullOverEnabled, "PullOver", NULL, settings_stop_pullover_registered, pullover_forget_remote_state, NULL, YES, YES },
@@ -1666,6 +1688,7 @@ static void settings_each_springboard_cleanup_entry(void (^block)(const Settings
 
 static BOOL settings_any_registered_live_loop_running(void)
 {
+    if (g_visual_refresh_live_running) return YES;
     __block BOOL running = NO;
     settings_each_springboard_cleanup_entry(^(const SettingsSpringBoardTweakCleanupEntry *entry) {
         if (!running && entry->isRunning && entry->isRunning()) running = YES;
@@ -1676,6 +1699,7 @@ static BOOL settings_any_registered_live_loop_running(void)
 static NSString *settings_registered_live_loop_status_string(void)
 {
     NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    [parts addObject:[NSString stringWithFormat:@"visual-refresh=%d", g_visual_refresh_live_running ? 1 : 0]];
     settings_each_springboard_cleanup_entry(^(const SettingsSpringBoardTweakCleanupEntry *entry) {
         if (!entry->isRunning) return;
         [parts addObject:[NSString stringWithFormat:@"%s=%d",
@@ -1790,6 +1814,8 @@ static const NSUInteger kNotificationIslandLiveMaxTicks = 43200;
 static const useconds_t kVelvetLiveIntervalUS = 1000000;
 static const useconds_t kVelvetLiveBackgroundIntervalUS = 2000000;
 static const NSUInteger kVelvetLiveMaxTicks = 7200;
+static const useconds_t kVisualRefreshIntervalUS = 750000;
+static const useconds_t kVisualRefreshBackgroundIntervalUS = 2000000;
 // Only Clock/Calendar need periodic repair; normal icons persist through the
 // model graft and should not be repainted during SpringBoard animations.
 static const useconds_t kThemerLiveIntervalUS = 2000000;
@@ -2758,6 +2784,7 @@ static BOOL settings_cleanup_in_progress(void)
 
 static void settings_request_all_live_loops_stop(const char *reason)
 {
+    settings_request_visual_refresh_stop();
     settings_each_springboard_cleanup_entry(^(const SettingsSpringBoardTweakCleanupEntry *entry) {
         if (entry->requestStop) entry->requestStop();
     });
@@ -5777,6 +5804,99 @@ static void settings_start_velvet_live_loop(void)
     });
 }
 
+static BOOL settings_visual_refresh_enabled(NSUserDefaults *d)
+{
+    return [d boolForKey:kSettingsCleanCCEnabled] ||
+           [d boolForKey:kSettingsFUGapEnabled] ||
+           [d boolForKey:kSettingsModuleSpacingEnabled] ||
+           [d boolForKey:kSettingsSugarCaneEnabled] ||
+           [d boolForKey:kSettingsBetterCCXIEnabled] ||
+           [d boolForKey:kSettingsMagmaEnabled] ||
+           [d boolForKey:kSettingsBetterCCIconsEnabled] ||
+           [d boolForKey:kSettingsCCNoPlatterDimEnabled] ||
+           [d boolForKey:kSettingsHapticCCEnabled] ||
+           [d boolForKey:kSettingsSecureCCEnabled] ||
+           [d boolForKey:kSettingsCylinderLiteEnabled] ||
+           [d boolForKey:kSettingsBlurryBadgesEnabled] ||
+           [d boolForKey:kSettingsAlkalineEnabled] ||
+           [d boolForKey:kSettingsRoundedIconsEnabled] ||
+           [d boolForKey:kSettingsWatchLayoutEnabled];
+}
+
+static void settings_visual_refresh_mark_if_ready(NSString *key, bool ready)
+{
+    if (ready && !settings_tweak_is_applied(key)) settings_mark_tweak_applied(key, YES);
+}
+
+static void settings_visual_refresh_tick(NSUserDefaults *d, BOOL fullScan)
+{
+    if (fullScan && [d boolForKey:kSettingsCleanCCEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsCleanCCEnabled, cleancc_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsFUGapEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsFUGapEnabled, fugap_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsModuleSpacingEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsModuleSpacingEnabled, modulespacing_apply_in_session());
+    if ([d boolForKey:kSettingsSugarCaneEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsSugarCaneEnabled, sugarcane_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsBetterCCXIEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsBetterCCXIEnabled, betterccxi_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsMagmaEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsMagmaEnabled, magma_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsBetterCCIconsEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsBetterCCIconsEnabled, betterccicons_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsCCNoPlatterDimEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsCCNoPlatterDimEnabled, ccnoplatterdim_apply_in_session());
+    if ([d boolForKey:kSettingsHapticCCEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsHapticCCEnabled, hapticcc_apply_in_session());
+    if ([d boolForKey:kSettingsSecureCCEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsSecureCCEnabled, securecc_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsCylinderLiteEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsCylinderLiteEnabled, cylinderlite_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsBlurryBadgesEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsBlurryBadgesEnabled, blurrybadges_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsAlkalineEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsAlkalineEnabled, alkaline_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsRoundedIconsEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsRoundedIconsEnabled, roundedicons_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsWatchLayoutEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsWatchLayoutEnabled, watchlayout_apply_in_session());
+}
+
+static void settings_start_visual_refresh_live_loop(void)
+{
+    NSUserDefaults *d = [NSUserDefaults standardUserDefaults];
+    if (!settings_visual_refresh_enabled(d) || !g_springboard_rc_ready ||
+        settings_cleanup_in_progress()) return;
+    if (__sync_lock_test_and_set(&g_visual_refresh_live_running, 1)) return;
+    g_visual_refresh_live_stop_requested = 0;
+
+    dispatch_async(dispatch_get_global_queue(0, 0), ^{
+        NSUInteger tick = 0;
+        printf("[SETTINGS] visual refresh loop started\n");
+        @try {
+            while (settings_visual_refresh_enabled(d) &&
+                   !settings_cleanup_in_progress() &&
+                   !g_visual_refresh_live_stop_requested) {
+                if (!g_settings_actions_running) {
+                    @synchronized (settings_rc_lock()) {
+                        if (!g_visual_refresh_live_stop_requested && g_springboard_rc_ready)
+                            settings_visual_refresh_tick(d, (tick % 4) == 0);
+                    }
+                }
+                tick++;
+                useconds_t interval = settings_live_interval(kVisualRefreshIntervalUS,
+                                                              kVisualRefreshBackgroundIntervalUS);
+                settings_live_loop_sleep_interruptible(0, interval,
+                                                       &g_visual_refresh_live_stop_requested);
+            }
+        } @finally {
+            printf("[SETTINGS] visual refresh loop exited enabled=%d stop=%d\n",
+                   settings_visual_refresh_enabled(d), g_visual_refresh_live_stop_requested);
+            __sync_lock_release(&g_visual_refresh_live_running);
+        }
+    });
+}
+
 static void settings_start_themer_live_loop(void)
 {
     if (!settings_device_supported()) return;
@@ -6326,7 +6446,7 @@ static void settings_log_pancake_config(NSUserDefaults *d, const char *prefix)
 
 static void settings_log_cylinderlite_config(NSUserDefaults *d, const char *prefix)
 {
-    log_user("[%s] Cylinder Lite config: depth=%ld perspective=%ld maxIcons=%ld.\n",
+    log_user("[%s] Cylinder Lite config: depth=%ld perspective=%ld scanLimit=512 requestedLimit=%ld pages=all taps=preserved.\n",
              prefix ?: "CFG",
              (long)[d integerForKey:kSettingsCylinderLiteDepth],
              (long)[d integerForKey:kSettingsCylinderLitePerspective],
@@ -6379,6 +6499,9 @@ static void settings_configure_control_center_tweaks(NSUserDefaults *d)
                        (int)[d integerForKey:kSettingsAlkalineGreen],
                        (int)[d integerForKey:kSettingsAlkalineBlue],
                        (int)[d integerForKey:kSettingsAlkalineAlphaPct]);
+    roundedicons_configure((int)[d integerForKey:kSettingsRoundedIconsRadius]);
+    watchlayout_configure((int)[d integerForKey:kSettingsWatchLayoutCompactPct],
+                          (int)[d integerForKey:kSettingsWatchLayoutScalePct]);
 }
 
 static void settings_log_split_tweak_config(NSString *masterKey, NSUserDefaults *d, const char *prefix)
@@ -6460,6 +6583,13 @@ static void settings_log_split_tweak_config(NSString *masterKey, NSUserDefaults 
                  (long)[d integerForKey:kSettingsAlkalineGreen],
                  (long)[d integerForKey:kSettingsAlkalineBlue],
                  (long)[d integerForKey:kSettingsAlkalineAlphaPct]);
+    } else if ([masterKey isEqualToString:kSettingsRoundedIconsEnabled]) {
+        log_user("[%s] Rounded Icons config: continuousRadius=%ldpt pages=all discovered.\n", tag,
+                 (long)[d integerForKey:kSettingsRoundedIconsRadius]);
+    } else if ([masterKey isEqualToString:kSettingsWatchLayoutEnabled]) {
+        log_user("[%s] Watch Layout config: compact=%ld%% scale=%ld%% circular=1 pages=all discovered.\n", tag,
+                 (long)[d integerForKey:kSettingsWatchLayoutCompactPct],
+                 (long)[d integerForKey:kSettingsWatchLayoutScalePct]);
     }
 }
 
@@ -6525,6 +6655,11 @@ static NSString *settings_split_tweak_master_key_for_key(NSString *key)
         [key isEqualToString:kSettingsAlkalineGreen] ||
         [key isEqualToString:kSettingsAlkalineBlue] ||
         [key isEqualToString:kSettingsAlkalineAlphaPct]) return kSettingsAlkalineEnabled;
+    if ([key isEqualToString:kSettingsRoundedIconsEnabled] ||
+        [key isEqualToString:kSettingsRoundedIconsRadius]) return kSettingsRoundedIconsEnabled;
+    if ([key isEqualToString:kSettingsWatchLayoutEnabled] ||
+        [key isEqualToString:kSettingsWatchLayoutCompactPct] ||
+        [key isEqualToString:kSettingsWatchLayoutScalePct]) return kSettingsWatchLayoutEnabled;
     return nil;
 }
 
@@ -7612,6 +7747,12 @@ static void settings_schedule_live_apply_for_key(NSString *key)
                     } else if ([masterKey isEqualToString:kSettingsAlkalineEnabled]) {
                         ok = [d boolForKey:kSettingsAlkalineEnabled] ? alkaline_apply_in_session() : alkaline_stop_in_session();
                         settings_mark_tweak_applied(kSettingsAlkalineEnabled, ok && [d boolForKey:kSettingsAlkalineEnabled]);
+                    } else if ([masterKey isEqualToString:kSettingsRoundedIconsEnabled]) {
+                        ok = [d boolForKey:kSettingsRoundedIconsEnabled] ? roundedicons_apply_in_session() : roundedicons_stop_in_session();
+                        settings_mark_tweak_applied(kSettingsRoundedIconsEnabled, ok && [d boolForKey:kSettingsRoundedIconsEnabled]);
+                    } else if ([masterKey isEqualToString:kSettingsWatchLayoutEnabled]) {
+                        ok = [d boolForKey:kSettingsWatchLayoutEnabled] ? watchlayout_apply_in_session() : watchlayout_stop_in_session();
+                        settings_mark_tweak_applied(kSettingsWatchLayoutEnabled, ok && [d boolForKey:kSettingsWatchLayoutEnabled]);
                     }
                     printf("[SETTINGS] live split tweak %s owner=%s result=%d\n", key.UTF8String, masterKey.UTF8String, ok);
                 }
@@ -8211,12 +8352,17 @@ void settings_register_defaults(void)
         kSettingsCylinderLiteEnabled: @NO,
         kSettingsCylinderLiteDepth: @-10,
         kSettingsCylinderLitePerspective: @650,
-        kSettingsCylinderLiteMaxIcons: @128,
+        kSettingsCylinderLiteMaxIcons: @512,
         kSettingsBarmojiEnabled: @NO,
         kSettingsBarmojiYOffset: @92,
         kSettingsBarmojiWidthPct: @92,
         kSettingsBarmojiFontSize: @21,
         kSettingsBarmojiBackgroundAlphaPct: @86,
+        kSettingsRoundedIconsEnabled: @NO,
+        kSettingsRoundedIconsRadius: @18,
+        kSettingsWatchLayoutEnabled: @NO,
+        kSettingsWatchLayoutCompactPct: @82,
+        kSettingsWatchLayoutScalePct: @88,
         kSettingsBlurryBadgesEnabled: @NO,
         kSettingsBlurryBadgesRed: @59,
         kSettingsBlurryBadgesGreen: @140,
@@ -8323,6 +8469,8 @@ void settings_register_defaults(void)
             kSettingsPancakeEnabled,
             kSettingsCylinderLiteEnabled,
             kSettingsBarmojiEnabled,
+            kSettingsRoundedIconsEnabled,
+            kSettingsWatchLayoutEnabled,
             kSettingsBlurryBadgesEnabled,
             kSettingsSnapperEnabled,
             kSettingsPullOverEnabled,
@@ -8351,6 +8499,72 @@ void settings_register_defaults(void)
         [defaults synchronize];
     }
     settings_install_screen_awake_observers();
+}
+
+typedef struct {
+    __unsafe_unretained NSString *key;
+    const char *name;
+    const char *effect;
+} SettingsTweakLogDescriptor;
+
+static void settings_log_tweak_plan_details(NSUserDefaults *d, BOOL pendingOnly)
+{
+    const SettingsTweakLogDescriptor entries[] = {
+        { kSettingsSBCEnabled, "SBCustomizer", "rewrites the live dock and home-screen icon grid" },
+        { kSettingsPowercuffEnabled, "Powercuff", "sends the selected thermal-pressure level to thermalmonitord" },
+        { kSettingsStatBarEnabled, "StatBar", "creates and refreshes the battery, memory, CPU, and network status overlay" },
+        { kSettingsNSBarEnabled, "NSBar", "creates a live network-speed status-bar overlay" },
+        { kSettingsNiceBarLiteEnabled, "NiceBar Lite", "renders the configured status-bar text slots and live values" },
+        { kSettingsRSSIDisplayEnabled, "Signal Readouts", "replaces signal glyphs with live cellular/Wi-Fi readouts" },
+        { kSettingsAxonLiteEnabled, "Axon Lite", "groups visible Notification Center requests by application" },
+        { kSettingsTypeBannerEnabled, "TypeBanner", "polls imagent and presents typing indicators below the Dynamic Island" },
+        { kSettingsNotificationIslandEnabled, "Notification Island", "mirrors SpringBoard notification banners through ActivityKit" },
+        { kSettingsVelvetEnabled, "Velvet", "restyles visible notification backgrounds, borders, corners, and text" },
+        { kSettingsCleanNCEnabled, "CleanNC", "removes supported Notification Center visual clutter" },
+        { kSettingsUnderTimeEnabled, "UnderTime", "adds a secondary live time label under the status-bar clock" },
+        { kSettingsZeppelinLiteEnabled, "Zeppelin Lite", "replaces supported carrier labels with the configured text" },
+        { kSettingsCleanHomeScreenEnabled, "CleanHomeScreen", "hides the selected badges, page dots, and icon labels" },
+        { kSettingsRealCCEnabled, "RealCC", "changes the selected Control Center connectivity toggles" },
+        { kSettingsCleanCCEnabled, "CleanCC", "adjusts Control Center material alpha and glass tint" },
+        { kSettingsFUGapEnabled, "FUGap", "moves visible Control Center containers by the configured offset" },
+        { kSettingsModuleSpacingEnabled, "ModuleSpacing", "applies the configured Control Center module radius" },
+        { kSettingsSugarCaneEnabled, "SugarCane", "adds live percentage labels to brightness and volume controls" },
+        { kSettingsBetterCCXIEnabled, "BetterCCXI", "applies the configured Control Center depth and lift pass" },
+        { kSettingsMagmaEnabled, "Magma", "tints visible Control Center glyphs with the configured color" },
+        { kSettingsBetterCCIconsEnabled, "BetterCCIcons", "rounds visible Control Center icon and module layers" },
+        { kSettingsCCNoPlatterDimEnabled, "CCNoPlatterDim", "reduces dimming on expanded Control Center platters" },
+        { kSettingsCCStatusEnabled, "CCStatus", "adds the configured network status header to Control Center" },
+        { kSettingsHapticCCEnabled, "HapticCC", "watches Control Center state changes and emits the selected haptic" },
+        { kSettingsSecureCCEnabled, "SecureCC", "blocks supported Control Center interaction while the UI is locked" },
+        { kSettingsHideLabelsEnabled, "HideLabels", "hides visible home-screen icon labels" },
+        { kSettingsFakeClockUpEnabled, "FakeClockUp", "changes the Clock icon animation speed" },
+        { kSettingsPancakeEnabled, "Pancake", "installs the configured left-edge home-screen gesture hint" },
+        { kSettingsCylinderLiteEnabled, "Cylinder Lite", "applies perspective depth to visible home-screen icons" },
+        { kSettingsBarmojiEnabled, "Barmoji", "adds the configured emoji strip overlay to SpringBoard" },
+        { kSettingsRoundedIconsEnabled, "Rounded Icons", "applies a continuous corner mask to every discovered Home Screen icon" },
+        { kSettingsWatchLayoutEnabled, "Watch Layout", "compacts every discovered icon page into a circular Apple Watch-style grid" },
+        { kSettingsBlurryBadgesEnabled, "BlurryBadges", "tints visible notification badges with the configured color" },
+        { kSettingsSnapperEnabled, "Snapper", "shows the configured crop-frame overlay" },
+        { kSettingsPullOverEnabled, "PullOver", "shows the configured slide-over tray shell" },
+        { kSettingsAlkalineEnabled, "Alkaline", "tints visible battery views with the configured color" },
+        { kSettingsAppSwitcherGridEnabled, "App Switcher Grid", "patches SpringBoard's app-switcher layout in memory" },
+        { kSettingsGravityLiteEnabled, "Gravity Lite", "adds gravity, collision, bounce, and motion steering to icon snapshots" },
+        { kSettingsLayoutExtrasEnabled, "Home Layout Extras", "adds the configured padding and scaling to home and dock icons" },
+        { kSettingsThemerEnabled, "Themer", "replaces app icon imagery using the selected local theme" },
+        { kSettingsSnowBoardLiteEnabled, "SnowBoard Lite", "applies the selected SnowBoard/IconBundles theme" },
+        { kSettingsLiveWPEnabled, "LiveWP", "plays the selected video behind SpringBoard" },
+        { kSettingsStageStripEnabled, "Dynamic Stage Lite", "installs the picker and two floating application scene hosts" },
+        { kSettingsFastLockXLiteEnabled, "FastLockX Lite", "arms the configured lock-screen authentication and unlock behavior" },
+        { kSettingsTweakLoaderEnabled, "TweakLoader", "runs all registered precompiled RemoteCall tweaks" },
+        { kSettingsQuickLoaderEnabled, "QuickLoader", "executes the selected local JavaScript tweak" },
+        { kSettingsRepoTweaksEnabled, "RepoTweaks", "executes enabled repository JavaScript tweaks" },
+    };
+    for (NSUInteger i = 0; i < sizeof(entries) / sizeof(entries[0]); i++) {
+        const SettingsTweakLogDescriptor *entry = &entries[i];
+        if (!settings_enabled_tweak_should_run(d, entry->key, pendingOnly)) continue;
+        log_user("[TWEAK] %s: %s; enabled=1 previouslyApplied=%d.\n",
+                 entry->name, entry->effect, settings_tweak_is_applied(entry->key));
+    }
 }
 
 static void settings_run_actions_internal(BOOL pendingOnly)
@@ -8446,6 +8660,8 @@ static void settings_run_actions_internal(BOOL pendingOnly)
             BOOL runPancake = settings_pancake_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsPancakeEnabled, springBoardPendingOnly);
             BOOL runCylinderLite = settings_cylinderlite_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsCylinderLiteEnabled, springBoardPendingOnly);
             BOOL runBarmoji = settings_barmoji_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsBarmojiEnabled, springBoardPendingOnly);
+            BOOL runRoundedIcons = settings_enabled_tweak_should_run(d, kSettingsRoundedIconsEnabled, springBoardPendingOnly);
+            BOOL runWatchLayout = settings_enabled_tweak_should_run(d, kSettingsWatchLayoutEnabled, springBoardPendingOnly);
             BOOL runBlurryBadges = settings_blurrybadges_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsBlurryBadgesEnabled, springBoardPendingOnly);
             BOOL runSnapper = settings_snapper_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsSnapperEnabled, springBoardPendingOnly);
             BOOL runPullOver = settings_pullover_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsPullOverEnabled, springBoardPendingOnly);
@@ -8466,7 +8682,7 @@ static void settings_run_actions_internal(BOOL pendingOnly)
                 settings_note_themer_stage_conflict(YES);
             }
             BOOL cleanupDisabledSpringBoardTweaks = settings_disabled_applied_springboard_cleanup_needed(d);
-            BOOL needsSpringBoardWork = runSBC || runDarkTweaks || runStatBar || runNSBar || runNiceBarLite || runRSSI || runAxonLite || runGravityLite || runLayoutExtras || runTypeBanner || runNotificationIsland || runVelvet || runCleanNC || runUnderTime || runZeppelinLite || runCleanHomeScreen || runRealCC || runCleanCC || runFUGap || runModuleSpacing || runSugarCane || runBetterCCXI || runMagma || runBetterCCIcons || runCCNoPlatterDim || runCCStatus || runHapticCC || runSecureCC || runHideLabels || runFakeClockUp || runPancake || runCylinderLite || runBarmoji || runBlurryBadges || runSnapper || runPullOver || runAlkaline || runTweakLoader || runAppSwitcherGrid || runThemer || runSnowBoardLite || runLiveWP || runStageStrip || runFastLockXLite || runQuickLoader || runRepoTweaks || cleanupDisabledSpringBoardTweaks;
+            BOOL needsSpringBoardWork = runSBC || runDarkTweaks || runStatBar || runNSBar || runNiceBarLite || runRSSI || runAxonLite || runGravityLite || runLayoutExtras || runTypeBanner || runNotificationIsland || runVelvet || runCleanNC || runUnderTime || runZeppelinLite || runCleanHomeScreen || runRealCC || runCleanCC || runFUGap || runModuleSpacing || runSugarCane || runBetterCCXI || runMagma || runBetterCCIcons || runCCNoPlatterDim || runCCStatus || runHapticCC || runSecureCC || runHideLabels || runFakeClockUp || runPancake || runCylinderLite || runBarmoji || runRoundedIcons || runWatchLayout || runBlurryBadges || runSnapper || runPullOver || runAlkaline || runTweakLoader || runAppSwitcherGrid || runThemer || runSnowBoardLite || runLiveWP || runStageStrip || runFastLockXLite || runQuickLoader || runRepoTweaks || cleanupDisabledSpringBoardTweaks;
             BOOL runSandboxEscape = [d boolForKey:kSettingsRunSandboxEscape] && (!pendingOnly || needsSpringBoardWork);
             // TypeBanner prewarms its hidden SpringBoard window during Apply
             // and reuses the open SpringBoard session for text-only updates.
@@ -8520,6 +8736,8 @@ static void settings_run_actions_internal(BOOL pendingOnly)
             if (runPancake) total++;
             if (runCylinderLite) total++;
             if (runBarmoji) total++;
+            if (runRoundedIcons) total++;
+            if (runWatchLayout) total++;
             if (runBlurryBadges) total++;
             if (runSnapper) total++;
             if (runPullOver) total++;
@@ -8566,6 +8784,8 @@ static void settings_run_actions_internal(BOOL pendingOnly)
             if (runPancake) [enabledTweaks addObject:@"pancake"];
             if (runCylinderLite) [enabledTweaks addObject:@"cylinderlite"];
             if (runBarmoji) [enabledTweaks addObject:@"barmoji"];
+            if (runRoundedIcons) [enabledTweaks addObject:@"rounded-icons"];
+            if (runWatchLayout) [enabledTweaks addObject:@"watch-layout"];
             if (runBlurryBadges) [enabledTweaks addObject:@"blurrybadges"];
             if (runSnapper) [enabledTweaks addObject:@"snapper"];
             if (runPullOver) [enabledTweaks addObject:@"pullover"];
@@ -8588,6 +8808,7 @@ static void settings_run_actions_internal(BOOL pendingOnly)
             log_user("[PLAN] %lu stages: %s\n",
                      (unsigned long)total,
                      enabledTweaks.count ? [[enabledTweaks componentsJoinedByString:@", "] UTF8String] : "none");
+            settings_log_tweak_plan_details(d, pendingOnly);
             if (runFastLockXLite && runStageStrip) {
                 log_user("[COMPAT] FastLockX Lite will arm before Dynamic Stage Lite starts its control loop.\n");
             }
@@ -9150,6 +9371,22 @@ static void settings_run_actions_internal(BOOL pendingOnly)
                         cyanide_upload_log_milestone(ok ? @"barmoji-applied" : @"barmoji-failed");
                     }
 
+                    if (runRoundedIcons) {
+                        settings_progress(&step, total, "Applying Rounded Icons to all pages");
+                        settings_log_split_tweak_config(kSettingsRoundedIconsEnabled, d, "RUN");
+                        bool ok = roundedicons_apply_in_session();
+                        settings_mark_tweak_applied(kSettingsRoundedIconsEnabled, ok && [d boolForKey:kSettingsRoundedIconsEnabled]);
+                        log_user("%s Rounded Icons %s.\n", ok ? "[OK]" : "[WARN]", ok ? "active on discovered icons" : "found no icon views");
+                    }
+
+                    if (runWatchLayout) {
+                        settings_progress(&step, total, "Applying Watch Layout to all pages");
+                        settings_log_split_tweak_config(kSettingsWatchLayoutEnabled, d, "RUN");
+                        bool ok = watchlayout_apply_in_session();
+                        settings_mark_tweak_applied(kSettingsWatchLayoutEnabled, ok && [d boolForKey:kSettingsWatchLayoutEnabled]);
+                        log_user("%s Watch Layout %s.\n", ok ? "[OK]" : "[WARN]", ok ? "active with tappable circular icons" : "found no icon views");
+                    }
+
                     if (runBlurryBadges) {
                         settings_progress(&step, total, "Applying BlurryBadges");
                         settings_log_split_tweak_config(kSettingsBlurryBadgesEnabled, d, "RUN");
@@ -9307,6 +9544,11 @@ static void settings_run_actions_internal(BOOL pendingOnly)
                 } else if (!velvetEnabled) {
                     g_velvet_live_stop_requested = 1;
                 }
+                if (settings_visual_refresh_enabled(d)) {
+                    settings_start_visual_refresh_live_loop();
+                } else {
+                    g_visual_refresh_live_stop_requested = 1;
+                }
             }
 
             if (runTypeBanner) {
@@ -9456,6 +9698,11 @@ typedef NS_ENUM(NSInteger, SettingsSection) {
     SectionTweakLoader,
     SectionQuickLoader,
     SectionRepoTweaks,
+    SectionStageStrip,
+    SectionCallRecordingSound,
+    SectionHideHomeBar,
+    SectionRoundedIcons,
+    SectionWatchLayout,
     SectionCount,
 };
 
@@ -9980,6 +10227,13 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
                                                                          action:@selector(navRespringTapped)];
         respringItem.accessibilityLabel = @"Respring";
         self.navigationItem.rightBarButtonItem = respringItem;
+    } else {
+        UIBarButtonItem *logsItem = [[UIBarButtonItem alloc] initWithTitle:@"Logs"
+                                                                    style:UIBarButtonItemStylePlain
+                                                                   target:self
+                                                                   action:@selector(openViewLog)];
+        logsItem.accessibilityLabel = @"View detailed tweak activity log";
+        self.navigationItem.rightBarButtonItem = logsItem;
     }
 }
 
@@ -10296,7 +10550,11 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
 
 - (NSArray<NSDictionary *> *)darkSwordTweakRows
 {
-    return @[];
+    return @[
+        @{ @"kind": @"info", @"title": @"Runtime behavior",
+           @"subtitle": @"The installed DarkSword patch changes SpringBoard in memory. A respring restores stock behavior." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
 }
 
 - (NSArray<NSDictionary *> *)dragCoefficientRows
@@ -10393,7 +10651,40 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
 
 - (NSArray<NSDictionary *> *)axonLiteRows
 {
-    return @[];
+    return @[
+        @{ @"kind": @"info", @"title": @"Grouping mode",
+           @"subtitle": @"Groups visible Notification Center requests by application and filters duplicate request identifiers." },
+        @{ @"kind": @"info", @"title": @"Session lifetime",
+           @"subtitle": @"Runs through infern0's live SpringBoard session and stops during cleanup or when infern0 exits." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
+}
+
+- (NSArray<NSDictionary *> *)stageStripRows
+{
+    return @[
+        @{ @"kind": @"info", @"title": @"Floating windows", @"subtitle": @"Hosts up to two movable, resizable application scenes from the bottom-right picker." },
+        @{ @"kind": @"info", @"title": @"First-run scan", @"subtitle": @"The initial run builds the installed-app picker cache; later runs reuse it." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
+}
+
+- (NSArray<NSDictionary *> *)callRecordingSoundRows
+{
+    return @[
+        @{ @"kind": @"info", @"title": @"Files changed", @"subtitle": @"Replaces CallServices disclosure audio with silent assets after saving first-original backups." },
+        @{ @"kind": @"info", @"title": @"Persistence", @"subtitle": @"This persists until the Installer restores the backed-up originals." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
+}
+
+- (NSArray<NSDictionary *> *)hideHomeBarRows
+{
+    return @[
+        @{ @"kind": @"info", @"title": @"Asset change", @"subtitle": @"Zeros the first page of MaterialKit Assets.car; SpringBoard reloads the result after a respring." },
+        @{ @"kind": @"info", @"title": @"Restore", @"subtitle": @"Use Restore Home Bar in the Installer, then respring again." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
 }
 
 - (NSArray<NSDictionary *> *)typebannerRows
@@ -10590,7 +10881,8 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         @{ @"kind": @"toggle", @"key": kSettingsCylinderLiteEnabled, @"title": @"Enable Cylinder Lite" },
         @{ @"kind": @"slider", @"key": kSettingsCylinderLiteDepth, @"title": @"Icon depth", @"min": @-80, @"max": @0, @"step": @1, @"default": @-10, @"unit": @"z" },
         @{ @"kind": @"slider", @"key": kSettingsCylinderLitePerspective, @"title": @"Perspective distance", @"min": @250, @"max": @1600, @"step": @25, @"default": @650 },
-        @{ @"kind": @"slider", @"key": kSettingsCylinderLiteMaxIcons, @"title": @"Max icons", @"min": @8, @"max": @256, @"step": @8, @"default": @128 },
+        @{ @"kind": @"info", @"title": @"Coverage", @"subtitle": @"Scans up to 512 live icons across every discovered Home Screen page and preserves icon interaction." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
     ];
 }
 
@@ -10602,6 +10894,29 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         @{ @"kind": @"slider", @"key": kSettingsBarmojiWidthPct, @"title": @"Bar width", @"min": @65, @"max": @100, @"step": @1, @"default": @92, @"unit": @"%" },
         @{ @"kind": @"slider", @"key": kSettingsBarmojiFontSize, @"title": @"Emoji size", @"min": @14, @"max": @28, @"step": @1, @"default": @21, @"unit": @"pt" },
         @{ @"kind": @"slider", @"key": kSettingsBarmojiBackgroundAlphaPct, @"title": @"Background alpha", @"min": @20, @"max": @100, @"step": @1, @"default": @86, @"unit": @"%" },
+        @{ @"kind": @"info", @"title": @"Press behavior", @"subtitle": @"Each emoji is a real button with highlight and selection feedback. The overlay does not inject text into another app's keyboard host." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
+}
+
+- (NSArray<NSDictionary *> *)roundedIconsRows
+{
+    return @[
+        @{ @"kind": @"toggle", @"key": kSettingsRoundedIconsEnabled, @"title": @"Enable Rounded Icons" },
+        @{ @"kind": @"slider", @"key": kSettingsRoundedIconsRadius, @"title": @"Corner radius", @"min": @4, @"max": @36, @"step": @1, @"default": @18, @"unit": @"pt" },
+        @{ @"kind": @"info", @"title": @"Coverage", @"subtitle": @"Applies a continuous mask to every discovered Home Screen page and keeps the original icons tappable." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
+}
+
+- (NSArray<NSDictionary *> *)watchLayoutRows
+{
+    return @[
+        @{ @"kind": @"toggle", @"key": kSettingsWatchLayoutEnabled, @"title": @"Enable Watch Layout" },
+        @{ @"kind": @"slider", @"key": kSettingsWatchLayoutCompactPct, @"title": @"Grid compactness", @"min": @60, @"max": @100, @"step": @1, @"default": @82, @"unit": @"%" },
+        @{ @"kind": @"slider", @"key": kSettingsWatchLayoutScalePct, @"title": @"Circular icon size", @"min": @60, @"max": @110, @"step": @1, @"default": @88, @"unit": @"%" },
+        @{ @"kind": @"info", @"title": @"Interaction", @"subtitle": @"Uses live SBIconViews instead of snapshots, so transformed icons still launch normally." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
     ];
 }
 
@@ -11274,6 +11589,11 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         case SectionLiveWP: return self.liveWPRows;
         case SectionQuickLoader: return self.quickLoaderRows;
         case SectionRepoTweaks: return self.repoTweaksRows;
+        case SectionStageStrip: return self.stageStripRows;
+        case SectionCallRecordingSound: return self.callRecordingSoundRows;
+        case SectionHideHomeBar: return self.hideHomeBarRows;
+        case SectionRoundedIcons: return self.roundedIconsRows;
+        case SectionWatchLayout: return self.watchLayoutRows;
         default: return @[];
     }
 }
@@ -11340,6 +11660,11 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         @{ @"title": @"SpringBoard Tweaks", @"icon": @"apps.iphone",                         @"color": [UIColor systemIndigoColor], @"section": @(SectionDarkSwordTweaks) },
         @{ @"title": @"Drag Coefficient",   @"icon": @"dial.medium.fill",                    @"color": [UIColor systemIndigoColor], @"section": @(SectionDragCoefficient) },
         @{ @"title": @"Home Layout Extras", @"icon": @"square.dashed.inset.filled",          @"color": [UIColor systemPurpleColor], @"section": @(SectionLayoutExtras) },
+#if CYANIDE_EXPERIMENTAL_TWEAKS_AVAILABLE
+        @{ @"title": @"Dynamic Stage Lite", @"icon": @"sidebar.left", @"color": [UIColor systemBlueColor], @"section": @(SectionStageStrip), @"indev": @YES },
+#endif
+        @{ @"title": @"Rounded Icons", @"icon": @"app.fill", @"color": [UIColor systemBlueColor], @"section": @(SectionRoundedIcons) },
+        @{ @"title": @"Watch Layout", @"icon": @"circle.grid.3x3.fill", @"color": [UIColor systemGreenColor], @"section": @(SectionWatchLayout) },
     ];
 }
 
@@ -11349,6 +11674,8 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         @{ @"title": @"OTA Updates",       @"icon": @"icloud.slash.fill",    @"color": [UIColor systemGrayColor],   @"section": @(SectionOTA) },
         @{ @"title": @"IPA Decryptor",     @"icon": @"lock.open.fill",       @"color": [UIColor systemGreenColor],  @"section": @(SectionIPADecryptor) },
         @{ @"title": @"Watch Pairing",     @"icon": @"applewatch.radiowaves.left.and.right", @"color": [UIColor systemPurpleColor], @"section": @(SectionNanoRegistry) },
+        @{ @"title": @"Call Recording Sound", @"icon": @"speaker.slash.fill", @"color": [UIColor systemOrangeColor], @"section": @(SectionCallRecordingSound) },
+        @{ @"title": @"Hide Home Bar", @"icon": @"line.3.horizontal", @"color": [UIColor systemGrayColor], @"section": @(SectionHideHomeBar) },
     ];
 }
 
@@ -11504,6 +11831,15 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
     if (s == SectionAxonLite) {
         return @"RemoteCall-only Axon port. It uses a live app-side loop rather than substrate hooks, so it lasts for the active infern0 SpringBoard session.";
     }
+    if (s == SectionStageStrip) {
+        return @"RemoteCall-only floating app windows. The first picker build can take one or two minutes; later runs reuse the cached app list. Touch routing inside hosted apps remains experimental.";
+    }
+    if (s == SectionCallRecordingSound) {
+        return @"Persistent CallServices file replacement. The log records every target, backup, write, verification, and restore result. Disclosure sounds may be legally required where you live.";
+    }
+    if (s == SectionHideHomeBar) {
+        return @"Persistent MaterialKit asset edit. Apply or restore it by itself, then respring. The log records the target path, write result, and pending-respring state.";
+    }
     if (s == SectionTypeBanner) {
         return @"Partial TypeMillennium port. Detection runs against imagent using original-thread RemoteCall probes, while SpringBoard renders a prewarmed banner window.";
     }
@@ -11571,10 +11907,16 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         return @"Adds a left-hand gesture hint to the home screen for one-handed navigation.";
     }
     if (s == SectionCylinderLite) {
-        return @"Adds perspective-based icon animations to the home screen when tilting the device.";
+        return @"Applies perspective depth to every discovered Home Screen page. It keeps each live SBIconView interactive so icons continue to open normally.";
     }
     if (s == SectionBarmoji) {
-        return @"Adds a lightweight emoji strip overlay near the bottom of SpringBoard.";
+        return @"Adds eight real emoji buttons near the bottom of SpringBoard. Buttons highlight and produce selection feedback when pressed. The enabled setting survives reboot; the live overlay is recreated when infern0 starts its SpringBoard session.";
+    }
+    if (s == SectionRoundedIcons) {
+        return @"Applies smooth continuous corners to every discovered Home Screen icon without requiring a theme. Live icon views remain tappable.";
+    }
+    if (s == SectionWatchLayout) {
+        return @"Compacts every discovered Home Screen page into a circular Apple Watch-style layout. Refreshes use saved stock frames, so the layout does not keep shrinking and can be restored.";
     }
     if (s == SectionBlurryBadges) {
         return @"Tints visible notification badge views for a softer, colorized badge look.";
@@ -13916,7 +14258,12 @@ void cyanide_present_contact(UIViewController *host)
     }
     NSString *key = row[@"key"];
     [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:key];
-    printf("[SETTINGS] toggle %s=%d\n", key.UTF8String, sender.isOn);
+    log_user("[SETTINGS] %s (%s) set to %s%s%s.\n",
+             [row[@"title"] UTF8String] ?: "Toggle",
+             key.UTF8String ?: "unknown-key",
+             sender.isOn ? "ON" : "OFF",
+             [row[@"subtitle"] length] ? " - " : "",
+             [row[@"subtitle"] length] ? [row[@"subtitle"] UTF8String] : "");
     settings_note_package_configuration_changed(key);
     if ([key isEqualToString:kSettingsKeepAlive]) {
         ds_keepalive_apply_enabled(sender.isOn);
@@ -13956,7 +14303,13 @@ void cyanide_present_contact(UIViewController *host)
     NSUserDefaults *d = [NSUserDefaults standardUserDefaults];
     BOOL showLocationLog = settings_key_is_location_sim(key) && settings_location_sim_is_active(d);
     [d setInteger:value forKey:key];
-    printf("[SETTINGS] slider %s=%ld\n", key.UTF8String, (long)value);
+    log_user("[SETTINGS] %s (%s) set to %ld%s%s%s.\n",
+             [row[@"title"] UTF8String] ?: "Slider",
+             key.UTF8String ?: "unknown-key",
+             (long)value,
+             [row[@"unit"] UTF8String] ?: "",
+             [row[@"subtitle"] length] ? " - " : "",
+             [row[@"subtitle"] length] ? [row[@"subtitle"] UTF8String] : "");
     settings_note_package_configuration_changed(key);
     if (showLocationLog) {
         [self presentActivityLogWithCompletion:^{
@@ -14040,7 +14393,12 @@ void cyanide_present_contact(UIViewController *host)
         [d synchronize];
 
         NSString *valueText = settings_number_row_value_string(row, value, YES);
-        printf("[SETTINGS] number %s=%s\n", key.UTF8String, valueText.UTF8String);
+        log_user("[SETTINGS] %s (%s) set to %s%s%s.\n",
+                 [row[@"title"] UTF8String] ?: "Number",
+                 key.UTF8String ?: "unknown-key",
+                 valueText.UTF8String ?: "",
+                 [row[@"subtitle"] length] ? " - " : "",
+                 [row[@"subtitle"] length] ? [row[@"subtitle"] UTF8String] : "");
         settings_note_package_configuration_changed(key);
         settings_schedule_live_apply_for_key(key);
         [strongSelf reloadSectionOrAll:section];
@@ -14962,6 +15320,13 @@ void cyanide_present_contact(UIViewController *host)
         }
     } else {
         indexPath = [NSIndexPath indexPathForRow:indexPath.row inSection:self.underlyingSection];
+    }
+
+    NSArray<NSDictionary *> *selectedRows = [self rowsForSection:indexPath.section];
+    if (indexPath.row < (NSInteger)selectedRows.count &&
+        [selectedRows[indexPath.row][@"action"] isEqualToString:@"view-log"]) {
+        [self openViewLog];
+        return;
     }
 
     if (!settings_device_supported() &&

--- a/Infern0/installer/PackageCatalog.m
+++ b/Infern0/installer/PackageCatalog.m
@@ -106,11 +106,13 @@ static BOOL catalog_repo_script_requires_native_bridge(NSString *rawScript)
 // Mirrors of the private SettingsSection enum values in SettingsViewController.m
 // (kept in sync — must match the underlying section indices used for the
 // detail-mode SettingsViewController push).
+static const NSInteger kSecOTA              = 3;
 static const NSInteger kSecSBC              = 4;
 static const NSInteger kSecStatBar          = 5;
 static const NSInteger kSecNSBar            = 6;
 static const NSInteger kSecNiceBarLite      = 7;
 static const NSInteger kSecRSSI             = 8;
+static const NSInteger kSecAxonLite         = 9;
 static const NSInteger kSecTypeBanner       = 10;
 static const NSInteger kSecNotificationIsland = 11;
 static const NSInteger kSecPowercuff        = 12;
@@ -153,6 +155,12 @@ static const NSInteger kSecAlkaline         = 50;
 static const NSInteger kSecTweakLoader      = 51;
 static const NSInteger kSecQuickLoader      = 52;
 static const NSInteger kSecRepoTweaks       = 53;
+static const NSInteger kSecStageStrip       = 54;
+static const NSInteger kSecCallRecordingSound = 55;
+static const NSInteger kSecHideHomeBar      = 56;
+static const NSInteger kSecRoundedIcons     = 57;
+static const NSInteger kSecWatchLayout      = 58;
+static const NSInteger kSecDarkSwordTweaks  = 13;
 
 + (NSArray<Package *> *)allPackages
 {
@@ -270,6 +278,7 @@ static const NSInteger kSecRepoTweaks       = 53;
                                            kind:PackageInstallKindToggle
                                      enabledKey:kSettingsAxonLiteEnabled
                                           isNew:NO];
+        axon.settingsSection = kSecAxonLite;
         axon.unstableWarning = @"⚠️ Experimental: work-in-progress. Expect SpringBoard crashes, dropped notifications, layout glitches, and breakage between infern0 builds. Don't rely on it for anything important.";
 
 #if CYANIDE_EXPERIMENTAL_TWEAKS_AVAILABLE
@@ -339,6 +348,7 @@ static const NSInteger kSecRepoTweaks       = 53;
                                            kind:PackageInstallKindToggle
                                      enabledKey:kSettingsStageStripEnabled
                                           isNew:NO];
+        stageStrip.settingsSection = kSecStageStrip;
         stageStrip.unstableWarning = @"Beta / unstable: First Run takes 1-2 minutes because the picker enumerates every installed app and builds a tile per app. Re-Runs are fast. Touch routing into hosted windows isn't wired yet, so scrolling/typing inside a floating window may not work.";
 #endif
 
@@ -742,8 +752,8 @@ static const NSInteger kSecRepoTweaks       = 53;
 
         Package *barmoji = [[Package alloc] initWithIdentifier:@"com.darksword.barmoji"
                                            name:@"Barmoji"
-                               shortDescription:@"Emoji strip overlay"
-                                longDescription:@"First-pass Barmoji port. Adds a lightweight most-used emoji strip overlay near the bottom of SpringBoard while infern0 is active.\n\nThis version is a SpringBoard overlay shell; deeper keyboard-host integration will come later."
+                               shortDescription:@"Pressable emoji button strip"
+                                longDescription:@"Adds eight real emoji buttons near the bottom of SpringBoard. Each button highlights and produces selection feedback when pressed. The enabled preference survives reboot, and infern0 recreates the live overlay when its SpringBoard session starts.\n\nCross-process insertion into arbitrary app text fields is not part of this SpringBoard overlay build."
                                         version:version
                                          author:@"Nnnnnnn274"
                                        category:@"SpringBoard"
@@ -752,7 +762,33 @@ static const NSInteger kSecRepoTweaks       = 53;
                                      enabledKey:kSettingsBarmojiEnabled
                                           isNew:YES];
         barmoji.settingsSection = kSecBarmoji;
-        barmoji.unstableWarning = @"Beta: overlay-only first pass. It does not yet inject into every app keyboard host.";
+        barmoji.unstableWarning = @"Beta: press feedback works in the SpringBoard overlay, but this build does not inject text into arbitrary app keyboard hosts.";
+
+        Package *roundedIcons = [[Package alloc] initWithIdentifier:@"com.darksword.roundedicons"
+                                           name:@"Rounded Icons"
+                               shortDescription:@"Smooth corners for every Home Screen icon"
+                                longDescription:@"Applies a configurable continuous corner radius directly to every discovered live Home Screen icon. No icon theme is required, all pages are scanned, and the original icon views remain tappable."
+                                        version:version
+                                         author:@"zeroxjf"
+                                       category:@"Home Screen"
+                                     symbolName:@"app.fill"
+                                           kind:PackageInstallKindToggle
+                                     enabledKey:kSettingsRoundedIconsEnabled
+                                          isNew:YES];
+        roundedIcons.settingsSection = kSecRoundedIcons;
+
+        Package *watchLayout = [[Package alloc] initWithIdentifier:@"com.darksword.watchlayout"
+                                           name:@"Watch Layout"
+                               shortDescription:@"Circular Apple Watch-style icon grid"
+                                longDescription:@"Compacts every discovered Home Screen page into a circular Apple Watch-style grid with circular icons and configurable spacing and scale. It transforms live icon views, so icons remain pressable, and saves stock frames for clean restoration."
+                                        version:version
+                                         author:@"zeroxjf"
+                                       category:@"Home Screen"
+                                     symbolName:@"circle.grid.3x3.fill"
+                                           kind:PackageInstallKindToggle
+                                     enabledKey:kSettingsWatchLayoutEnabled
+                                          isNew:YES];
+        watchLayout.settingsSection = kSecWatchLayout;
 
         Package *blurryBadges = [[Package alloc] initWithIdentifier:@"com.darksword.blurrybadges"
                                            name:@"BlurryBadges"
@@ -847,6 +883,7 @@ static const NSInteger kSecRepoTweaks       = 53;
                                            kind:PackageInstallKindCallRecordingSound
                                      enabledKey:nil
                                           isNew:NO];
+        callRecordingSound.settingsSection = kSecCallRecordingSound;
         callRecordingSound.experimental = NO;
         callRecordingSound.unstableWarning = @"Beta: persistent CallServices system-file replacement. Disclosure sounds may be legally required where you live; you are responsible for your use and apply this at your own risk. Use Restore Original Sounds before removing infern0 if you want infern0's backups written back.";
 
@@ -861,6 +898,7 @@ static const NSInteger kSecRepoTweaks       = 53;
                                            kind:PackageInstallKindHideHomeBar
                                      enabledKey:nil
                                           isNew:NO];
+        hideHomeBar.settingsSection = kSecHideHomeBar;
         hideHomeBar.unstableWarning = @"Beta: system asset page zeroing. Run by itself, then respring after hiding. To restore the home indicator, choose Restore Home Bar and respring.";
 
         Package *otaBlock = [[Package alloc] initWithIdentifier:@"com.darksword.ota-block"
@@ -874,6 +912,7 @@ static const NSInteger kSecRepoTweaks       = 53;
                                           kind:PackageInstallKindOTA
                                     enabledKey:nil
                                          isNew:NO];
+        otaBlock.settingsSection = kSecOTA;
         otaBlock.unstableWarning = @"Warning: persistent system-file edit. This package modifies launchd disabled.plist to change OTA job state across reboot. Disable or re-enable OTA updates at your own risk.";
 
         Package *disableAppLibrary = [[Package alloc] initWithIdentifier:@"com.darksword.disable-app-library"
@@ -1001,6 +1040,8 @@ static const NSInteger kSecRepoTweaks       = 53;
             pancake,
             cylinderLite,
             barmoji,
+            roundedIcons,
+            watchLayout,
             blurryBadges,
             snapper,
             pullOver,
@@ -1013,6 +1054,18 @@ static const NSInteger kSecRepoTweaks       = 53;
             appSwitcherGrid,
             quickLoader,
         ];
+        NSSet<NSString *> *darkSwordIDs = [NSSet setWithArray:@[
+            @"com.darksword.disable-app-library",
+            @"com.darksword.disable-icon-flyin",
+            @"com.darksword.zero-wake-animation",
+            @"com.darksword.zero-backlight-fade",
+            @"com.darksword.double-tap-to-lock",
+        ]];
+        for (Package *package in list) {
+            if ([darkSwordIDs containsObject:package.identifier]) {
+                package.settingsSection = kSecDarkSwordTweaks;
+            }
+        }
     });
     NSArray<Package *> *repoPackages = [self repoPackages];
     if (repoPackages.count == 0) return list;

--- a/Infern0/tweaks/experimental/alkaline.m
+++ b/Infern0/tweaks/experimental/alkaline.m
@@ -1,5 +1,6 @@
 #import "alkaline.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -73,7 +74,7 @@ static void alkaline_scan_and_tint(uint64_t parent, uint64_t color, int depth, i
 bool alkaline_apply_in_session(void)
 {
     printf("[ALKALINE] apply\n");
-    uint64_t win = alkaline_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     gAlkalineTint = alkaline_color((double)gAlkalineRed / 255.0,
                                    (double)gAlkalineGreen / 255.0,
@@ -88,7 +89,7 @@ bool alkaline_apply_in_session(void)
 bool alkaline_stop_in_session(void)
 {
     printf("[ALKALINE] stop\n");
-    uint64_t win = alkaline_key_window();
+    uint64_t win = sb_frontmost_window();
     uint64_t white = alkaline_color(1, 1, 1, 1);
     int hits = 0;
     if (r_is_objc_ptr(win)) alkaline_scan_and_tint(win, white, 0, &hits);

--- a/Infern0/tweaks/experimental/barmoji.m
+++ b/Infern0/tweaks/experimental/barmoji.m
@@ -1,5 +1,6 @@
 #import "barmoji.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -12,6 +13,7 @@ typedef struct {
 } BarmojiRect;
 
 static uint64_t gBarmojiView = 0;
+static uint64_t gBarmojiFeedback = 0;
 static int gBarmojiYOffset = 92;
 static int gBarmojiWidthPercent = 92;
 static int gBarmojiFontSize = 21;
@@ -26,27 +28,6 @@ static uint64_t barmoji_color(double red, double green, double blue, double alph
                            &green, sizeof(green),
                            &blue, sizeof(blue),
                            &alpha, sizeof(alpha));
-}
-
-static uint64_t barmoji_key_window(void)
-{
-    uint64_t UIApplication = r_class("UIApplication");
-    if (!r_is_objc_ptr(UIApplication)) return 0;
-    uint64_t app = r_msg2_main(UIApplication, "sharedApplication", 0, 0, 0, 0);
-    if (!r_is_objc_ptr(app)) return 0;
-
-    uint64_t windows = r_msg2_main(app, "windows", 0, 0, 0, 0);
-    if (r_is_objc_ptr(windows)) {
-        uint64_t count = r_msg2_main(windows, "count", 0, 0, 0, 0);
-        if (count > 64) count = 64;
-        for (uint64_t i = 0; i < count; i++) {
-            uint64_t win = r_msg2_main(windows, "objectAtIndex:", i, 0, 0, 0);
-            if (!r_is_objc_ptr(win)) continue;
-            uint64_t isKey = r_msg2_main(win, "isKeyWindow", 0, 0, 0, 0);
-            if (isKey & 0xff) return win;
-        }
-    }
-    return r_msg2_main(app, "keyWindow", 0, 0, 0, 0);
 }
 
 static BarmojiRect barmoji_bounds_for_view(uint64_t view)
@@ -72,33 +53,36 @@ static uint64_t barmoji_alloc_view(double x, double y, double w, double h)
     return r_is_objc_ptr(view) ? view : 0;
 }
 
-static uint64_t barmoji_alloc_label(const char *text, double x, double y, double w, double h, double fontSize)
+static uint64_t barmoji_alloc_button(const char *emoji, double x, double y,
+                                     double w, double h, double fontSize)
 {
-    uint64_t UILabel = r_class("UILabel");
-    if (!r_is_objc_ptr(UILabel)) return 0;
-    uint64_t label = r_msg2_main(UILabel, "alloc", 0, 0, 0, 0);
-    if (!r_is_objc_ptr(label)) return 0;
+    uint64_t UIButton = r_class("UIButton");
+    if (!r_is_objc_ptr(UIButton)) return 0;
+    uint64_t button = r_msg2_main(UIButton, "buttonWithType:", 0, 0, 0, 0);
+    if (!r_is_objc_ptr(button)) return 0;
     BarmojiRect frame = { x, y, w, h };
-    label = r_msg2_main_raw(label, "initWithFrame:", &frame, sizeof(frame), NULL, 0, NULL, 0, NULL, 0);
-    if (!r_is_objc_ptr(label)) return 0;
-
-    uint64_t str = r_nsstr_retained(text ?: "");
-    if (r_is_objc_ptr(str)) {
-        r_msg2_main(label, "setText:", str, 0, 0, 0);
-        r_msg2_main(str, "release", 0, 0, 0, 0);
+    r_msg2_main_raw(button, "setFrame:", &frame, sizeof(frame), NULL, 0, NULL, 0, NULL, 0);
+    uint64_t title = r_nsstr_retained(emoji ?: "");
+    if (r_is_objc_ptr(title)) {
+        r_msg2_main(button, "setTitle:forState:", title, 0, 0, 0);
+        r_msg2_main(title, "release", 0, 0, 0, 0);
     }
-
+    uint64_t label = r_msg2_main(button, "titleLabel", 0, 0, 0, 0);
     uint64_t UIFont = r_class("UIFont");
-    if (r_is_objc_ptr(UIFont)) {
-        double weight = 0.4;
-        uint64_t font = r_msg2_main_raw(UIFont, "systemFontOfSize:weight:",
+    if (r_is_objc_ptr(label) && r_is_objc_ptr(UIFont)) {
+        uint64_t font = r_msg2_main_raw(UIFont, "systemFontOfSize:",
                                         &fontSize, sizeof(fontSize),
-                                        &weight, sizeof(weight),
-                                        NULL, 0, NULL, 0);
+                                        NULL, 0, NULL, 0, NULL, 0);
         if (r_is_objc_ptr(font)) r_msg2_main(label, "setFont:", font, 0, 0, 0);
     }
-    r_msg2_main(label, "setTextAlignment:", 1, 0, 0, 0);
-    return label;
+    r_msg2_main(button, "setShowsTouchWhenHighlighted:", 1, 0, 0, 0);
+    r_msg2_main(button, "setExclusiveTouch:", 1, 0, 0, 0);
+    r_msg2_main(button, "setUserInteractionEnabled:", 1, 0, 0, 0);
+    if (r_is_objc_ptr(gBarmojiFeedback)) {
+        r_msg2_main(button, "addTarget:action:forControlEvents:",
+                    gBarmojiFeedback, r_sel("selectionChanged"), 1ULL << 6, 0);
+    }
+    return button;
 }
 
 bool barmoji_apply_in_session(void)
@@ -109,7 +93,7 @@ bool barmoji_apply_in_session(void)
         gBarmojiView = 0;
     }
 
-    uint64_t win = barmoji_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     BarmojiRect bounds = barmoji_bounds_for_view(win);
     double barWidth = bounds.width * ((double)gBarmojiWidthPercent / 100.0);
@@ -119,6 +103,15 @@ bool barmoji_apply_in_session(void)
     double barY = bounds.height - (double)gBarmojiYOffset;
     uint64_t bar = barmoji_alloc_view(barX, barY, barWidth, 38);
     if (!r_is_objc_ptr(bar)) return false;
+    r_msg2_main(bar, "setUserInteractionEnabled:", 1, 0, 0, 0);
+
+    if (!r_is_objc_ptr(gBarmojiFeedback)) {
+        uint64_t feedbackClass = r_class("UISelectionFeedbackGenerator");
+        gBarmojiFeedback = r_is_objc_ptr(feedbackClass)
+            ? r_msg2_main(feedbackClass, "new", 0, 0, 0, 0) : 0;
+    }
+    if (r_is_objc_ptr(gBarmojiFeedback))
+        r_msg2_main(gBarmojiFeedback, "prepare", 0, 0, 0, 0);
 
     uint64_t bg = barmoji_color(0.16, 0.16, 0.18, (double)gBarmojiBackgroundAlphaPercent / 100.0);
     if (r_is_objc_ptr(bg)) r_msg2_main(bar, "setBackgroundColor:", bg, 0, 0, 0);
@@ -134,25 +127,26 @@ bool barmoji_apply_in_session(void)
         r_msg2_main_raw(layer, "setBorderWidth:", &borderWidth, sizeof(borderWidth), NULL, 0, NULL, 0, NULL, 0);
     }
 
-    const char *emojiStrip =
-        "\xF0\x9F\x98\x80  "
-        "\xF0\x9F\x98\x82  "
-        "\xE2\x9D\xA4\xEF\xB8\x8F  "
-        "\xF0\x9F\x91\x8D  "
-        "\xF0\x9F\x99\x8F  "
-        "\xF0\x9F\x94\xA5  "
-        "\xF0\x9F\x98\xAD  "
-        "\xE2\x9C\xA8";
-    uint64_t label = barmoji_alloc_label(emojiStrip, 8, 2, barWidth - 16.0, 34, (double)gBarmojiFontSize);
-    if (r_is_objc_ptr(label)) {
-        uint64_t white = barmoji_color(1, 1, 1, 1);
-        if (r_is_objc_ptr(white)) r_msg2_main(label, "setTextColor:", white, 0, 0, 0);
-        r_msg2_main(bar, "addSubview:", label, 0, 0, 0);
+    const char *emojis[] = {
+        "\xF0\x9F\x98\x80", "\xF0\x9F\x98\x82", "\xE2\x9D\xA4\xEF\xB8\x8F",
+        "\xF0\x9F\x91\x8D", "\xF0\x9F\x99\x8F", "\xF0\x9F\x94\xA5",
+        "\xF0\x9F\x98\xAD", "\xE2\x9C\xA8"
+    };
+    double buttonWidth = (barWidth - 12.0) / 8.0;
+    int buttonCount = 0;
+    for (int i = 0; i < 8; i++) {
+        uint64_t button = barmoji_alloc_button(emojis[i], 6.0 + buttonWidth * i,
+                                               2.0, buttonWidth, 34.0,
+                                               (double)gBarmojiFontSize);
+        if (!r_is_objc_ptr(button)) continue;
+        r_msg2_main(bar, "addSubview:", button, 0, 0, 0);
+        buttonCount++;
     }
 
     r_msg2_main(win, "addSubview:", bar, 0, 0, 0);
     gBarmojiView = bar;
-    return true;
+    printf("[BARMOJI] interactive buttons=%d window=0x%llx\n", buttonCount, win);
+    return buttonCount == 8;
 }
 
 bool barmoji_stop_in_session(void)
@@ -160,6 +154,8 @@ bool barmoji_stop_in_session(void)
     printf("[BARMOJI] stop\n");
     if (r_is_objc_ptr(gBarmojiView)) r_msg2_main(gBarmojiView, "removeFromSuperview", 0, 0, 0, 0);
     gBarmojiView = 0;
+    if (r_is_objc_ptr(gBarmojiFeedback)) r_msg2_main(gBarmojiFeedback, "release", 0, 0, 0, 0);
+    gBarmojiFeedback = 0;
     return true;
 }
 
@@ -179,4 +175,4 @@ void barmoji_configure(int yOffset, int widthPercent, int fontSize, int backgrou
     gBarmojiBackgroundAlphaPercent = backgroundAlphaPercent;
 }
 
-void barmoji_forget_remote_state(void) { gBarmojiView = 0; }
+void barmoji_forget_remote_state(void) { gBarmojiView = 0; gBarmojiFeedback = 0; }

--- a/Infern0/tweaks/experimental/betterccicons.m
+++ b/Infern0/tweaks/experimental/betterccicons.m
@@ -1,5 +1,6 @@
 #import "betterccicons.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -54,7 +55,7 @@ static void betterccicons_scan(uint64_t parent, double radius, int depth, int *h
 bool betterccicons_apply_in_session(void)
 {
     printf("[BETTERCCICONS] apply\n");
-    uint64_t win = betterccicons_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     int hits = 0;
     betterccicons_scan(win, (double)gBetterCCIconsCornerRadius, 0, &hits);
@@ -65,7 +66,7 @@ bool betterccicons_apply_in_session(void)
 bool betterccicons_stop_in_session(void)
 {
     printf("[BETTERCCICONS] stop\n");
-    uint64_t win = betterccicons_key_window();
+    uint64_t win = sb_frontmost_window();
     int hits = 0;
     if (r_is_objc_ptr(win)) betterccicons_scan(win, 12.0, 0, &hits);
     gBetterCCIconsApplied = false;

--- a/Infern0/tweaks/experimental/betterccxi.m
+++ b/Infern0/tweaks/experimental/betterccxi.m
@@ -1,5 +1,6 @@
 #import "betterccxi.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -57,7 +58,7 @@ static void betterccxi_scan(uint64_t parent, double scale, int depth, int *hits)
 bool betterccxi_apply_in_session(void)
 {
     printf("[BETTERCCXI] apply\n");
-    uint64_t win = betterccxi_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     int hits = 0;
     betterccxi_scan(win, 1.0, 0, &hits);
@@ -68,7 +69,7 @@ bool betterccxi_apply_in_session(void)
 bool betterccxi_stop_in_session(void)
 {
     printf("[BETTERCCXI] stop\n");
-    uint64_t win = betterccxi_key_window();
+    uint64_t win = sb_frontmost_window();
     int hits = 0;
     int old = gBetterCCXIZLift;
     gBetterCCXIZLift = 0;

--- a/Infern0/tweaks/experimental/blurrybadges.m
+++ b/Infern0/tweaks/experimental/blurrybadges.m
@@ -1,5 +1,6 @@
 #import "blurrybadges.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -85,7 +86,7 @@ static void blurrybadges_scan_and_tint(uint64_t parent, uint64_t color, int dept
 bool blurrybadges_apply_in_session(void)
 {
     printf("[BLURRYBADGES] apply\n");
-    uint64_t win = blurrybadges_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     gBlurryBadgesTint = blurrybadges_color((double)gBlurryBadgesRed / 255.0,
                                            (double)gBlurryBadgesGreen / 255.0,
@@ -100,7 +101,7 @@ bool blurrybadges_apply_in_session(void)
 bool blurrybadges_stop_in_session(void)
 {
     printf("[BLURRYBADGES] stop\n");
-    uint64_t win = blurrybadges_key_window();
+    uint64_t win = sb_frontmost_window();
     uint64_t red = blurrybadges_color(1.0, 0.23, 0.19, 1.0);
     int hits = 0;
     if (r_is_objc_ptr(win)) blurrybadges_scan_and_tint(win, red, 0, &hits);

--- a/Infern0/tweaks/experimental/ccnoplatterdim.m
+++ b/Infern0/tweaks/experimental/ccnoplatterdim.m
@@ -1,5 +1,6 @@
 #import "ccnoplatterdim.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -52,7 +53,7 @@ static void ccnoplatterdim_scan(uint64_t parent, double alpha, int depth, int *h
 bool ccnoplatterdim_apply_in_session(void)
 {
     printf("[CCNOPLATTERDIM] apply\n");
-    uint64_t win = ccnoplatterdim_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     int hits = 0;
     ccnoplatterdim_scan(win, (double)gCCNoPlatterDimVisibleAlphaPercent / 100.0, 0, &hits);
@@ -63,7 +64,7 @@ bool ccnoplatterdim_apply_in_session(void)
 bool ccnoplatterdim_stop_in_session(void)
 {
     printf("[CCNOPLATTERDIM] stop\n");
-    uint64_t win = ccnoplatterdim_key_window();
+    uint64_t win = sb_frontmost_window();
     int hits = 0;
     if (r_is_objc_ptr(win)) ccnoplatterdim_scan(win, 1.0, 0, &hits);
     gCCNoPlatterDimApplied = false;

--- a/Infern0/tweaks/experimental/ccstatus.m
+++ b/Infern0/tweaks/experimental/ccstatus.m
@@ -1,5 +1,6 @@
 #import "ccstatus.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -35,7 +36,7 @@ bool ccstatus_apply_in_session(void)
         r_msg2_main(gCCStatusLabel, "removeFromSuperview", 0, 0, 0, 0);
         gCCStatusLabel = 0;
     }
-    uint64_t win = ccstatus_key_window();
+    uint64_t win = sb_frontmost_window();
     uint64_t UILabel = r_class("UILabel");
     if (!r_is_objc_ptr(win) || !r_is_objc_ptr(UILabel)) return false;
     uint64_t label = r_msg2_main(UILabel, "alloc", 0, 0, 0, 0);

--- a/Infern0/tweaks/experimental/cleancc.m
+++ b/Infern0/tweaks/experimental/cleancc.m
@@ -1,5 +1,6 @@
 #import "cleancc.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -67,7 +68,7 @@ static void cleancc_scan(uint64_t parent, uint64_t color, double alpha, int dept
 bool cleancc_apply_in_session(void)
 {
     printf("[CLEANCC] apply\n");
-    uint64_t win = cleancc_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     double tintAlpha = (double)gCleanCCGlassTintPercent / 100.0;
     double materialAlpha = (double)gCleanCCMaterialAlphaPercent / 100.0;
@@ -83,7 +84,7 @@ bool cleancc_apply_in_session(void)
 bool cleancc_stop_in_session(void)
 {
     printf("[CLEANCC] stop\n");
-    uint64_t win = cleancc_key_window();
+    uint64_t win = sb_frontmost_window();
     uint64_t clear = cleancc_color(0, 0, 0, 0);
     int hits = 0;
     if (r_is_objc_ptr(win)) cleancc_scan(win, clear, 1.0, 0, &hits);

--- a/Infern0/tweaks/experimental/cylinderlite.m
+++ b/Infern0/tweaks/experimental/cylinderlite.m
@@ -1,5 +1,6 @@
 #import "cylinderlite.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 #import "../../LogTextView.h"
 
@@ -11,7 +12,7 @@ static bool gCyApplied = false;
 static uint64_t gCyLastIconListView = 0;
 static int gCyDepth = -10;
 static int gCyPerspectiveDistance = 650;
-static int gCyMaxIcons = 128;
+static int gCyMaxIcons = 512;
 
 typedef struct {
     double m11, m12, m13, m14;
@@ -46,113 +47,54 @@ bool cylinderlite_apply_in_session(void)
 {
     printf("[CYLINDER] apply\n");
 
-    uint64_t UIApplication = r_class("UIApplication");
-    if (!r_is_objc_ptr(UIApplication)) return false;
-    uint64_t app = r_msg2_main(UIApplication, "sharedApplication", 0, 0, 0, 0);
-    if (!r_is_objc_ptr(app)) return false;
+    uint64_t iconViews[512] = {0};
+    uint64_t listViews[64] = {0};
+    uint64_t iconClass = r_class("SBIconView");
+    uint64_t listClass = r_class("SBIconListView");
+    if (!r_is_objc_ptr(iconClass) || !r_is_objc_ptr(listClass)) return false;
 
-    uint64_t windows = r_msg2_main(app, "windows", 0, 0, 0, 0);
-    if (!r_is_objc_ptr(windows)) return false;
-    uint64_t winCount = r_msg2_main(windows, "count", 0, 0, 0, 0);
-    if (winCount > 32) winCount = 32;
-
-    uint64_t iconListView = 0;
-    for (uint64_t i = 0; i < winCount; i++) {
-        uint64_t win = r_msg2_main(windows, "objectAtIndex:", i, 0, 0, 0);
-        if (!r_is_objc_ptr(win)) continue;
-        uint64_t root = r_msg2_main(win, "rootViewController", 0, 0, 0, 0);
-        if (!r_is_objc_ptr(root)) continue;
-
-        char cls[128] = {0};
-        uint64_t rCls = r_dlsym_call(R_TIMEOUT, "object_getClass", root, 0, 0, 0, 0, 0, 0, 0);
-        if (r_is_objc_ptr(rCls)) {
-            uint64_t name = r_dlsym_call(R_TIMEOUT, "class_getName", rCls, 0, 0, 0, 0, 0, 0, 0);
-            if (name) {
-                uint64_t buf = r_dlsym_call(R_TIMEOUT, "strdup", name, 0, 0, 0, 0, 0, 0, 0);
-                if (buf) {
-                    remote_read(buf, cls, sizeof(cls) - 1);
-                    r_free(buf);
-                }
-            }
-        }
-
-        if (strstr(cls, "SBIconController") || strstr(cls, "SBRootFolder")) {
-            iconListView = r_msg2_main(root, "currentIconListView", 0, 0, 0, 0);
-            if (r_is_objc_ptr(iconListView)) break;
-
-            uint64_t folder = r_msg2_main(root, "rootFolder", 0, 0, 0, 0);
-            if (!r_is_objc_ptr(folder)) folder = r_ivar_value(root, "_rootFolder");
-            if (r_is_objc_ptr(folder)) {
-                uint64_t listViews = r_msg2_main(folder, "iconListViews", 0, 0, 0, 0);
-                if (!r_is_objc_ptr(listViews)) listViews = r_ivar_value(folder, "_iconListViews");
-                if (r_is_objc_ptr(listViews)) {
-                    uint64_t lvCount = r_msg2_main(listViews, "count", 0, 0, 0, 0);
-                    if (lvCount > 0) {
-                        iconListView = r_msg2_main(listViews, "firstObject", 0, 0, 0, 0);
-                        if (r_is_objc_ptr(iconListView)) break;
-                    }
-                }
-            }
-        }
+    int iconCount = sb_collect_views_in_windows(iconClass, iconViews, gCyMaxIcons);
+    int listCount = sb_collect_views_in_windows(listClass, listViews, 64);
+    double z = (double)gCyDepth;
+    for (int i = 0; i < iconCount; i++) {
+        r_msg2_main(iconViews[i], "setUserInteractionEnabled:", 1, 0, 0, 0);
+        uint64_t layer = r_msg2_main(iconViews[i], "layer", 0, 0, 0, 0);
+        if (r_is_objc_ptr(layer))
+            r_msg2_main_raw(layer, "setZPosition:", &z, sizeof(z), NULL, 0, NULL, 0, NULL, 0);
     }
-
-    if (!r_is_objc_ptr(iconListView)) {
-        printf("[CYLINDER] no icon list view found\n");
-        return false;
-    }
-    gCyLastIconListView = iconListView;
-
-    uint64_t subviews = r_msg2_main(iconListView, "subviews", 0, 0, 0, 0);
-    if (!r_is_objc_ptr(subviews)) return false;
-    uint64_t iconCount = r_msg2_main(subviews, "count", 0, 0, 0, 0);
-    if (iconCount > (uint64_t)gCyMaxIcons) iconCount = (uint64_t)gCyMaxIcons;
-
-    for (uint64_t i = 0; i < iconCount; i++) {
-        uint64_t sv = r_msg2_main(subviews, "objectAtIndex:", i, 0, 0, 0);
-        if (!r_is_objc_ptr(sv)) continue;
-
-        char cls[128] = {0};
-        uint64_t rCls = r_dlsym_call(R_TIMEOUT, "object_getClass", sv, 0, 0, 0, 0, 0, 0, 0);
-        if (r_is_objc_ptr(rCls)) {
-            uint64_t name = r_dlsym_call(R_TIMEOUT, "class_getName", rCls, 0, 0, 0, 0, 0, 0, 0);
-            if (name) {
-                uint64_t buf = r_dlsym_call(R_TIMEOUT, "strdup", name, 0, 0, 0, 0, 0, 0, 0);
-                if (buf) {
-                    remote_read(buf, cls, sizeof(cls) - 1);
-                    r_free(buf);
-                }
-            }
-        }
-
-        if (strstr(cls, "SBIconView") || strstr(cls, "SBIcon")) {
-            uint64_t layer = r_msg2_main(sv, "layer", 0, 0, 0, 0);
-            if (r_is_objc_ptr(layer)) {
-                double z = (double)gCyDepth;
-                r_msg2_main_raw(layer, "setZPosition:", &z, sizeof(z), NULL, 0, NULL, 0, NULL, 0);
-                printf("[CYLINDER] set depth on icon 0x%llx\n", sv);
-            }
-        }
-    }
-
-    printf("[CYLINDER] applied depth transforms to %llu icon views\n", iconCount);
-
-    uint64_t layer = r_msg2_main(iconListView, "layer", 0, 0, 0, 0);
-    if (r_is_objc_ptr(layer)) {
+    for (int i = 0; i < listCount; i++) {
+        r_msg2_main(listViews[i], "setUserInteractionEnabled:", 1, 0, 0, 0);
+        uint64_t layer = r_msg2_main(listViews[i], "layer", 0, 0, 0, 0);
         cy_apply_perspective_to_layer(layer, true);
-        printf("[CYLINDER] set perspective transform on list view\n");
     }
+    gCyLastIconListView = listCount > 0 ? listViews[0] : 0;
+    printf("[CYLINDER] transformed icons=%d lists=%d scanLimit=%d pages=all-discovered taps=preserved\n",
+           iconCount, listCount, gCyMaxIcons);
 
-    gCyApplied = true;
-    return true;
+    gCyApplied = iconCount > 0 && listCount > 0;
+    return gCyApplied;
 }
 
 bool cylinderlite_stop_in_session(void)
 {
     printf("[CYLINDER] stop\n");
-    if (r_is_objc_ptr(gCyLastIconListView)) {
-        uint64_t layer = r_msg2_main(gCyLastIconListView, "layer", 0, 0, 0, 0);
+    uint64_t iconViews[512] = {0};
+    uint64_t listViews[64] = {0};
+    uint64_t iconClass = r_class("SBIconView");
+    uint64_t listClass = r_class("SBIconListView");
+    int iconCount = r_is_objc_ptr(iconClass) ? sb_collect_views_in_windows(iconClass, iconViews, 512) : 0;
+    int listCount = r_is_objc_ptr(listClass) ? sb_collect_views_in_windows(listClass, listViews, 64) : 0;
+    double z = 0.0;
+    for (int i = 0; i < iconCount; i++) {
+        uint64_t layer = r_msg2_main(iconViews[i], "layer", 0, 0, 0, 0);
+        if (r_is_objc_ptr(layer))
+            r_msg2_main_raw(layer, "setZPosition:", &z, sizeof(z), NULL, 0, NULL, 0, NULL, 0);
+    }
+    for (int i = 0; i < listCount; i++) {
+        uint64_t layer = r_msg2_main(listViews[i], "layer", 0, 0, 0, 0);
         cy_apply_perspective_to_layer(layer, false);
     }
+    gCyLastIconListView = 0;
     gCyApplied = false;
     return true;
 }
@@ -163,8 +105,8 @@ void cylinderlite_configure(int depth, int perspectiveDistance, int maxIcons)
     if (depth < -80) depth = -80;
     if (perspectiveDistance < 250) perspectiveDistance = 250;
     if (perspectiveDistance > 1600) perspectiveDistance = 1600;
-    if (maxIcons < 8) maxIcons = 8;
-    if (maxIcons > 256) maxIcons = 256;
+    if (maxIcons < 512) maxIcons = 512;
+    if (maxIcons > 512) maxIcons = 512;
     gCyDepth = depth;
     gCyPerspectiveDistance = perspectiveDistance;
     gCyMaxIcons = maxIcons;

--- a/Infern0/tweaks/experimental/fugap.m
+++ b/Infern0/tweaks/experimental/fugap.m
@@ -1,5 +1,6 @@
 #import "fugap.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -56,7 +57,7 @@ static void fugap_scan(uint64_t parent, double offset, int depth, int *hits)
 bool fugap_apply_in_session(void)
 {
     printf("[FUGAP] apply\n");
-    uint64_t win = fugap_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     int hits = 0;
     fugap_scan(win, (double)gFUGapYOffset, 0, &hits);
@@ -67,7 +68,7 @@ bool fugap_apply_in_session(void)
 bool fugap_stop_in_session(void)
 {
     printf("[FUGAP] stop\n");
-    uint64_t win = fugap_key_window();
+    uint64_t win = sb_frontmost_window();
     int hits = 0;
     if (r_is_objc_ptr(win)) fugap_scan(win, 0.0, 0, &hits);
     gFUGapApplied = false;

--- a/Infern0/tweaks/experimental/hapticcc.m
+++ b/Infern0/tweaks/experimental/hapticcc.m
@@ -1,31 +1,97 @@
 #import "hapticcc.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
+#import <string.h>
 
 static bool gHapticCCApplied = false;
 static int gHapticCCFeedbackStyle = 1;
+static uint64_t gHapticCCControls[64] = {0};
+static uint8_t gHapticCCStates[64] = {0};
+static int gHapticCCControlCount = 0;
 
-bool hapticcc_apply_in_session(void)
+static void hapticcc_class_name(uint64_t obj, char *out, size_t outLen)
 {
-    printf("[HAPTICCC] apply\n");
+    if (!out || outLen == 0) return;
+    out[0] = '\0';
+    uint64_t cls = r_is_objc_ptr(obj) ?
+        r_dlsym_call(R_TIMEOUT, "object_getClass", obj, 0, 0, 0, 0, 0, 0, 0) : 0;
+    uint64_t name = r_is_objc_ptr(cls) ?
+        r_dlsym_call(R_TIMEOUT, "class_getName", cls, 0, 0, 0, 0, 0, 0, 0) : 0;
+    if (!name) return;
+    uint64_t copy = r_dlsym_call(R_TIMEOUT, "strdup", name, 0, 0, 0, 0, 0, 0, 0);
+    if (!copy) return;
+    remote_read(copy, out, outLen - 1);
+    out[outLen - 1] = '\0';
+    r_free(copy);
+}
+
+static void hapticcc_fire(void)
+{
     uint64_t Generator = r_class("UIImpactFeedbackGenerator");
-    if (!r_is_objc_ptr(Generator)) return false;
-    uint64_t gen = r_msg2_main(Generator, "alloc", 0, 0, 0, 0);
-    uint64_t style = (uint64_t)gHapticCCFeedbackStyle;
-    gen = r_msg2_main(gen, "initWithStyle:", style, 0, 0, 0);
-    if (!r_is_objc_ptr(gen)) return false;
+    uint64_t gen = r_is_objc_ptr(Generator) ? r_msg2_main(Generator, "alloc", 0, 0, 0, 0) : 0;
+    gen = r_is_objc_ptr(gen) ? r_msg2_main(gen, "initWithStyle:", (uint64_t)gHapticCCFeedbackStyle, 0, 0, 0) : 0;
+    if (!r_is_objc_ptr(gen)) return;
     r_msg2_main(gen, "prepare", 0, 0, 0, 0);
     r_msg2_main(gen, "impactOccurred", 0, 0, 0, 0);
     r_msg2_main(gen, "release", 0, 0, 0, 0);
-    gHapticCCApplied = true;
-    return true;
+}
+
+static void hapticcc_scan(uint64_t view, int depth, int *hits, bool *fired)
+{
+    if (!r_is_objc_ptr(view) || depth > 14) return;
+    char cls[160] = {0};
+    hapticcc_class_name(view, cls, sizeof(cls));
+    bool ccView = strstr(cls, "CCUI") || strstr(cls, "ControlCenter");
+    const char *stateSelector = r_responds_main(view, "isSelected") ? "isSelected" :
+                                (r_responds_main(view, "isOn") ? "isOn" : NULL);
+    if (ccView && stateSelector) {
+        uint8_t state = (uint8_t)(r_msg2_main(view, stateSelector, 0, 0, 0, 0) & 0xff);
+        int index = -1;
+        for (int i = 0; i < gHapticCCControlCount; i++) {
+            if (gHapticCCControls[i] == view) { index = i; break; }
+        }
+        if (index < 0 && gHapticCCControlCount < 64) {
+            index = gHapticCCControlCount++;
+            gHapticCCControls[index] = view;
+            gHapticCCStates[index] = state;
+        } else if (index >= 0 && gHapticCCStates[index] != state) {
+            gHapticCCStates[index] = state;
+            if (fired && !*fired) { hapticcc_fire(); *fired = true; }
+        }
+        if (hits) (*hits)++;
+    }
+    uint64_t subviews = r_msg2_main(view, "subviews", 0, 0, 0, 0);
+    uint64_t count = r_is_objc_ptr(subviews) ? r_msg2_main(subviews, "count", 0, 0, 0, 0) : 0;
+    if (count > 160) count = 160;
+    for (uint64_t i = 0; i < count; i++)
+        hapticcc_scan(r_msg2_main(subviews, "objectAtIndex:", i, 0, 0, 0), depth + 1, hits, fired);
+}
+
+bool hapticcc_apply_in_session(void)
+{
+    uint64_t win = sb_frontmost_window();
+    if (!r_is_objc_ptr(win)) return false;
+    int hits = 0;
+    bool fired = false;
+    hapticcc_scan(win, 0, &hits, &fired);
+    if (hits == 0) {
+        memset(gHapticCCControls, 0, sizeof(gHapticCCControls));
+        memset(gHapticCCStates, 0, sizeof(gHapticCCStates));
+        gHapticCCControlCount = 0;
+    }
+    gHapticCCApplied = hits > 0;
+    return gHapticCCApplied;
 }
 
 bool hapticcc_stop_in_session(void)
 {
     printf("[HAPTICCC] stop\n");
+    memset(gHapticCCControls, 0, sizeof(gHapticCCControls));
+    memset(gHapticCCStates, 0, sizeof(gHapticCCStates));
+    gHapticCCControlCount = 0;
     gHapticCCApplied = false;
     return true;
 }
@@ -37,4 +103,10 @@ void hapticcc_configure(int feedbackStyle)
     gHapticCCFeedbackStyle = feedbackStyle;
 }
 
-void hapticcc_forget_remote_state(void) { gHapticCCApplied = false; }
+void hapticcc_forget_remote_state(void)
+{
+    memset(gHapticCCControls, 0, sizeof(gHapticCCControls));
+    memset(gHapticCCStates, 0, sizeof(gHapticCCStates));
+    gHapticCCControlCount = 0;
+    gHapticCCApplied = false;
+}

--- a/Infern0/tweaks/experimental/iconstyles.h
+++ b/Infern0/tweaks/experimental/iconstyles.h
@@ -1,0 +1,16 @@
+#ifndef iconstyles_h
+#define iconstyles_h
+
+#include <stdbool.h>
+
+void roundedicons_configure(int cornerRadius);
+bool roundedicons_apply_in_session(void);
+bool roundedicons_stop_in_session(void);
+void roundedicons_forget_remote_state(void);
+
+void watchlayout_configure(int compactPercent, int iconScalePercent);
+bool watchlayout_apply_in_session(void);
+bool watchlayout_stop_in_session(void);
+void watchlayout_forget_remote_state(void);
+
+#endif

--- a/Infern0/tweaks/experimental/iconstyles.m
+++ b/Infern0/tweaks/experimental/iconstyles.m
@@ -1,0 +1,187 @@
+#import "iconstyles.h"
+#import "../remote_objc.h"
+#import "../sb_walk.h"
+#import "../../TaskRop/RemoteCall.h"
+
+#import <Foundation/Foundation.h>
+#import <math.h>
+#import <string.h>
+
+typedef struct { double x, y, width, height; } ISRect;
+typedef struct { double a, b, c, d, tx, ty; } ISAffineTransform;
+
+static int gRoundedRadius = 18;
+static int gWatchCompactPercent = 82;
+static int gWatchScalePercent = 88;
+static uint64_t gWatchIcons[512] = {0};
+static ISRect gWatchFrames[512] = {0};
+static int gWatchIconCount = 0;
+
+static bool is_get_rect(uint64_t obj, const char *selector, ISRect *out)
+{
+    if (!r_is_objc_ptr(obj) || !out || !r_responds_main(obj, selector)) return false;
+    memset(out, 0, sizeof(*out));
+    return r_msg2_main_struct_ret(obj, selector, out, sizeof(*out),
+                                  NULL, 0, NULL, 0, NULL, 0, NULL, 0);
+}
+
+static void is_set_rect(uint64_t obj, const char *selector, ISRect value)
+{
+    if (!r_is_objc_ptr(obj) || !r_responds_main(obj, selector)) return;
+    r_msg2_main_raw(obj, selector, &value, sizeof(value), NULL, 0, NULL, 0, NULL, 0);
+}
+
+static uint64_t is_icon_image_view(uint64_t icon)
+{
+    const char *selectors[] = { "_iconImageView", "iconImageView", "_imageView", NULL };
+    for (int i = 0; selectors[i]; i++) {
+        if (!r_responds_main(icon, selectors[i])) continue;
+        uint64_t view = r_msg2_main(icon, selectors[i], 0, 0, 0, 0);
+        if (r_is_objc_ptr(view)) return view;
+    }
+    return icon;
+}
+
+static void is_round_view(uint64_t view, double radius)
+{
+    uint64_t layer = r_is_objc_ptr(view) ? r_msg2_main(view, "layer", 0, 0, 0, 0) : 0;
+    if (!r_is_objc_ptr(layer)) return;
+    r_msg2_main_raw(layer, "setCornerRadius:", &radius, sizeof(radius), NULL, 0, NULL, 0, NULL, 0);
+    r_msg2_main(layer, "setMasksToBounds:", radius > 0.0, 0, 0, 0);
+    if (r_responds_main(layer, "setCornerCurve:")) {
+        uint64_t curve = r_nsstr_retained("continuous");
+        if (r_is_objc_ptr(curve)) {
+            r_msg2_main(layer, "setCornerCurve:", curve, 0, 0, 0);
+            r_msg2_main(curve, "release", 0, 0, 0, 0);
+        }
+    }
+}
+
+void roundedicons_configure(int cornerRadius)
+{
+    if (cornerRadius < 0) cornerRadius = 0;
+    if (cornerRadius > 36) cornerRadius = 36;
+    gRoundedRadius = cornerRadius;
+}
+
+bool roundedicons_apply_in_session(void)
+{
+    uint64_t iconClass = r_class("SBIconView");
+    uint64_t icons[512] = {0};
+    int count = r_is_objc_ptr(iconClass) ? sb_collect_views_in_windows(iconClass, icons, 512) : 0;
+    int rounded = 0;
+    for (int i = 0; i < count; i++) {
+        uint64_t icon = icons[i];
+        uint64_t image = is_icon_image_view(icon);
+        if (!r_is_objc_ptr(image)) continue;
+        is_round_view(image, (double)gRoundedRadius);
+        r_msg2_main(icon, "setUserInteractionEnabled:", 1, 0, 0, 0);
+        rounded++;
+    }
+    printf("[ROUNDEDICONS] radius=%d applied=%d discovered=%d taps=preserved\n",
+           gRoundedRadius, rounded, count);
+    return rounded > 0;
+}
+
+bool roundedicons_stop_in_session(void)
+{
+    uint64_t iconClass = r_class("SBIconView");
+    uint64_t icons[512] = {0};
+    int count = r_is_objc_ptr(iconClass) ? sb_collect_views_in_windows(iconClass, icons, 512) : 0;
+    for (int i = 0; i < count; i++) is_round_view(is_icon_image_view(icons[i]), 0.0);
+    printf("[ROUNDEDICONS] restored=%d\n", count);
+    return true;
+}
+
+void roundedicons_forget_remote_state(void) {}
+
+void watchlayout_configure(int compactPercent, int iconScalePercent)
+{
+    if (compactPercent < 60) compactPercent = 60;
+    if (compactPercent > 100) compactPercent = 100;
+    if (iconScalePercent < 60) iconScalePercent = 60;
+    if (iconScalePercent > 110) iconScalePercent = 110;
+    gWatchCompactPercent = compactPercent;
+    gWatchScalePercent = iconScalePercent;
+}
+
+static int is_saved_watch_icon_index(uint64_t icon)
+{
+    for (int i = 0; i < gWatchIconCount; i++) if (gWatchIcons[i] == icon) return i;
+    return -1;
+}
+
+bool watchlayout_apply_in_session(void)
+{
+    uint64_t iconClass = r_class("SBIconView");
+    uint64_t icons[512] = {0};
+    int count = r_is_objc_ptr(iconClass) ? sb_collect_views_in_windows(iconClass, icons, 512) : 0;
+    int changed = 0;
+    double compact = (double)gWatchCompactPercent / 100.0;
+    double scale = (double)gWatchScalePercent / 100.0;
+    ISAffineTransform transform = { scale, 0, 0, scale, 0, 0 };
+    for (int i = 0; i < count; i++) {
+        uint64_t icon = icons[i];
+        uint64_t parent = r_is_objc_ptr(icon) ? r_msg2_main(icon, "superview", 0, 0, 0, 0) : 0;
+        ISRect frame, bounds;
+        if (!r_is_objc_ptr(parent) || !is_get_rect(icon, "frame", &frame) ||
+            !is_get_rect(parent, "bounds", &bounds) || frame.width <= 0 || frame.height <= 0) continue;
+        int savedIndex = is_saved_watch_icon_index(icon);
+        if (savedIndex < 0 && gWatchIconCount < 512) {
+            gWatchIcons[gWatchIconCount] = icon;
+            gWatchFrames[gWatchIconCount] = frame;
+            savedIndex = gWatchIconCount;
+            gWatchIconCount++;
+        }
+        if (savedIndex >= 0) frame = gWatchFrames[savedIndex];
+        double cx = frame.x + frame.width * 0.5;
+        double cy = frame.y + frame.height * 0.5;
+        double pcx = bounds.x + bounds.width * 0.5;
+        double pcy = bounds.y + bounds.height * 0.5;
+        cx = pcx + (cx - pcx) * compact;
+        cy = pcy + (cy - pcy) * compact;
+        frame.x = cx - frame.width * 0.5;
+        frame.y = cy - frame.height * 0.5;
+        is_set_rect(icon, "setFrame:", frame);
+        if (r_responds_main(icon, "setTransform:"))
+            r_msg2_main_raw(icon, "setTransform:", &transform, sizeof(transform), NULL, 0, NULL, 0, NULL, 0);
+        uint64_t image = is_icon_image_view(icon);
+        ISRect imageBounds;
+        double radius = 30.0 * scale;
+        if (is_get_rect(image, "bounds", &imageBounds) && imageBounds.width > 0 && imageBounds.height > 0)
+            radius = fmin(imageBounds.width, imageBounds.height) * 0.5;
+        is_round_view(image, radius);
+        r_msg2_main(icon, "setUserInteractionEnabled:", 1, 0, 0, 0);
+        changed++;
+    }
+    printf("[WATCHLAYOUT] compact=%d%% scale=%d%% icons=%d pages=all-discovered taps=preserved\n",
+           gWatchCompactPercent, gWatchScalePercent, changed);
+    return changed > 0;
+}
+
+bool watchlayout_stop_in_session(void)
+{
+    ISAffineTransform identity = {1, 0, 0, 1, 0, 0};
+    int restored = 0;
+    for (int i = 0; i < gWatchIconCount; i++) {
+        uint64_t icon = gWatchIcons[i];
+        if (!r_is_objc_ptr(icon)) continue;
+        is_set_rect(icon, "setFrame:", gWatchFrames[i]);
+        if (r_responds_main(icon, "setTransform:"))
+            r_msg2_main_raw(icon, "setTransform:", &identity, sizeof(identity), NULL, 0, NULL, 0, NULL, 0);
+        is_round_view(is_icon_image_view(icon), 0.0);
+        restored++;
+    }
+    memset(gWatchIcons, 0, sizeof(gWatchIcons));
+    memset(gWatchFrames, 0, sizeof(gWatchFrames));
+    gWatchIconCount = 0;
+    printf("[WATCHLAYOUT] restored=%d\n", restored);
+    return true;
+}
+
+void watchlayout_forget_remote_state(void)
+{
+    memset(gWatchIcons, 0, sizeof(gWatchIcons));
+    memset(gWatchFrames, 0, sizeof(gWatchFrames));
+    gWatchIconCount = 0;
+}

--- a/Infern0/tweaks/experimental/magma.m
+++ b/Infern0/tweaks/experimental/magma.m
@@ -1,5 +1,6 @@
 #import "magma.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -65,7 +66,7 @@ static void magma_scan(uint64_t parent, uint64_t color, int depth, int *hits)
 bool magma_apply_in_session(void)
 {
     printf("[MAGMA] apply\n");
-    uint64_t win = magma_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     gMagmaTint = magma_color((double)gMagmaRed / 255.0,
                              (double)gMagmaGreen / 255.0,
@@ -79,7 +80,7 @@ bool magma_apply_in_session(void)
 bool magma_stop_in_session(void)
 {
     printf("[MAGMA] stop\n");
-    uint64_t win = magma_key_window();
+    uint64_t win = sb_frontmost_window();
     uint64_t white = magma_color(1, 1, 1, 1);
     int hits = 0;
     if (r_is_objc_ptr(win)) magma_scan(win, white, 0, &hits);

--- a/Infern0/tweaks/experimental/modulespacing.m
+++ b/Infern0/tweaks/experimental/modulespacing.m
@@ -1,5 +1,6 @@
 #import "modulespacing.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -56,7 +57,7 @@ static void modulespacing_scan(uint64_t parent, double radius, int depth, int *h
 bool modulespacing_apply_in_session(void)
 {
     printf("[MODULESPACING] apply\n");
-    uint64_t win = modulespacing_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     int hits = 0;
     modulespacing_scan(win, (double)gModuleSpacingCornerRadius, 0, &hits);
@@ -67,7 +68,7 @@ bool modulespacing_apply_in_session(void)
 bool modulespacing_stop_in_session(void)
 {
     printf("[MODULESPACING] stop\n");
-    uint64_t win = modulespacing_key_window();
+    uint64_t win = sb_frontmost_window();
     int hits = 0;
     if (r_is_objc_ptr(win)) modulespacing_scan(win, 18.0, 0, &hits);
     gModuleSpacingApplied = false;

--- a/Infern0/tweaks/experimental/pullover.m
+++ b/Infern0/tweaks/experimental/pullover.m
@@ -1,5 +1,6 @@
 #import "pullover.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -124,7 +125,7 @@ bool pullover_apply_in_session(void)
         r_msg2_main(gPullOverView, "removeFromSuperview", 0, 0, 0, 0);
         gPullOverView = 0;
     }
-    uint64_t win = pullover_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     PullOverRect bounds = pullover_bounds_for_view(win);
     double trayHeight = bounds.height - 260.0;

--- a/Infern0/tweaks/experimental/realcc.m
+++ b/Infern0/tweaks/experimental/realcc.m
@@ -51,7 +51,7 @@ bool realcc_apply(bool disableWifi, bool disableBt)
 
     if (disableBt) {
         BOOL ok = realcc_write_plist_bool(@"/private/var/preferences/SystemConfiguration/com.apple.Bluetooth.plist",
-                                           @"BluetoothState", @NO);
+                                           @"BluetoothState", NO);
         if (ok) {
             realcc_kill_daemon("bluetoothd");
         }
@@ -75,7 +75,7 @@ bool realcc_restore(void)
 
     if (gRealccBtDisabled) {
         realcc_write_plist_bool(@"/private/var/preferences/SystemConfiguration/com.apple.Bluetooth.plist",
-                                @"BluetoothState", @YES);
+                                @"BluetoothState", YES);
         realcc_kill_daemon("bluetoothd");
         gRealccBtDisabled = false;
     }

--- a/Infern0/tweaks/experimental/securecc.m
+++ b/Infern0/tweaks/experimental/securecc.m
@@ -1,15 +1,62 @@
 #import "securecc.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
 #import <stdio.h>
+#import <string.h>
 
 typedef struct { double x; double y; double width; double height; } SecureCCRect;
 
 static uint64_t gSecureCCBanner = 0;
 static bool gSecureCCShowIndicator = true;
 static int gSecureCCDelayMs = 750;
+
+static bool securecc_is_locked(bool *locked)
+{
+    if (!locked) return false;
+    uint64_t cls = r_class("SBLockScreenManager");
+    uint64_t manager = r_is_objc_ptr(cls) ? r_msg2_main(cls, "sharedInstance", 0, 0, 0, 0) : 0;
+    if (!r_is_objc_ptr(manager)) return false;
+    const char *selector = r_responds_main(manager, "isUILocked") ? "isUILocked" :
+                           (r_responds_main(manager, "isLocked") ? "isLocked" : NULL);
+    if (!selector) return false;
+    *locked = (r_msg2_main(manager, selector, 0, 0, 0, 0) & 0xff) != 0;
+    return true;
+}
+
+static void securecc_class_name(uint64_t obj, char *out, size_t outLen)
+{
+    if (!out || outLen == 0) return;
+    out[0] = '\0';
+    uint64_t cls = r_is_objc_ptr(obj) ? r_dlsym_call(R_TIMEOUT, "object_getClass", obj, 0, 0, 0, 0, 0, 0, 0) : 0;
+    uint64_t name = r_is_objc_ptr(cls) ? r_dlsym_call(R_TIMEOUT, "class_getName", cls, 0, 0, 0, 0, 0, 0, 0) : 0;
+    if (!name) return;
+    uint64_t copy = r_dlsym_call(R_TIMEOUT, "strdup", name, 0, 0, 0, 0, 0, 0, 0);
+    if (!copy) return;
+    remote_read(copy, out, outLen - 1);
+    out[outLen - 1] = '\0';
+    r_free(copy);
+}
+
+static void securecc_set_controls_enabled(uint64_t view, bool enabled, int depth, int *hits)
+{
+    if (!r_is_objc_ptr(view) || depth > 14) return;
+    char cls[160] = {0};
+    securecc_class_name(view, cls, sizeof(cls));
+    bool ccControl = (strstr(cls, "CCUI") || strstr(cls, "ControlCenter")) &&
+                     (strstr(cls, "Button") || strstr(cls, "Module") || strstr(cls, "Control"));
+    if (ccControl && r_responds_main(view, "setUserInteractionEnabled:")) {
+        r_msg2_main(view, "setUserInteractionEnabled:", enabled ? 1 : 0, 0, 0, 0);
+        if (hits) (*hits)++;
+    }
+    uint64_t subviews = r_msg2_main(view, "subviews", 0, 0, 0, 0);
+    uint64_t count = r_is_objc_ptr(subviews) ? r_msg2_main(subviews, "count", 0, 0, 0, 0) : 0;
+    if (count > 160) count = 160;
+    for (uint64_t i = 0; i < count; i++)
+        securecc_set_controls_enabled(r_msg2_main(subviews, "objectAtIndex:", i, 0, 0, 0), enabled, depth + 1, hits);
+}
 
 static uint64_t securecc_color(double red, double green, double blue, double alpha)
 {
@@ -30,17 +77,22 @@ static uint64_t securecc_key_window(void)
 
 bool securecc_apply_in_session(void)
 {
-    printf("[SECURECC] apply\n");
-    if (!gSecureCCShowIndicator) {
+    bool locked = false;
+    if (!securecc_is_locked(&locked)) return false;
+    uint64_t win = sb_frontmost_window();
+    int controls = 0;
+    if (r_is_objc_ptr(win)) securecc_set_controls_enabled(win, !locked, 0, &controls);
+    if (!locked || !gSecureCCShowIndicator) {
         if (r_is_objc_ptr(gSecureCCBanner)) r_msg2_main(gSecureCCBanner, "removeFromSuperview", 0, 0, 0, 0);
         gSecureCCBanner = 0;
         return true;
     }
+    if (r_is_objc_ptr(gSecureCCBanner) &&
+        r_is_objc_ptr(r_msg2_main(gSecureCCBanner, "superview", 0, 0, 0, 0))) return true;
     if (r_is_objc_ptr(gSecureCCBanner)) {
         r_msg2_main(gSecureCCBanner, "removeFromSuperview", 0, 0, 0, 0);
         gSecureCCBanner = 0;
     }
-    uint64_t win = securecc_key_window();
     uint64_t UILabel = r_class("UILabel");
     if (!r_is_objc_ptr(win) || !r_is_objc_ptr(UILabel)) return false;
     uint64_t label = r_msg2_main(UILabel, "alloc", 0, 0, 0, 0);
@@ -80,6 +132,8 @@ bool securecc_stop_in_session(void)
 {
     printf("[SECURECC] stop\n");
     if (r_is_objc_ptr(gSecureCCBanner)) r_msg2_main(gSecureCCBanner, "removeFromSuperview", 0, 0, 0, 0);
+    uint64_t win = sb_frontmost_window();
+    if (r_is_objc_ptr(win)) securecc_set_controls_enabled(win, true, 0, NULL);
     gSecureCCBanner = 0;
     return true;
 }

--- a/Infern0/tweaks/experimental/snapper.m
+++ b/Infern0/tweaks/experimental/snapper.m
@@ -1,5 +1,6 @@
 #import "snapper.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -97,7 +98,7 @@ bool snapper_apply_in_session(void)
         r_msg2_main(gSnapperView, "removeFromSuperview", 0, 0, 0, 0);
         gSnapperView = 0;
     }
-    uint64_t win = snapper_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     uint64_t frame = snapper_alloc_view((double)gSnapperX,
                                         (double)gSnapperY,

--- a/Infern0/tweaks/experimental/sugarcane.m
+++ b/Infern0/tweaks/experimental/sugarcane.m
@@ -1,5 +1,6 @@
 #import "sugarcane.h"
 #import "../remote_objc.h"
+#import "../sb_walk.h"
 #import "../../TaskRop/RemoteCall.h"
 
 #import <Foundation/Foundation.h>
@@ -9,6 +10,7 @@
 typedef struct { double x; double y; double width; double height; } SugarCaneRect;
 
 static uint64_t gSugarCaneLabels[8] = {0};
+static uint64_t gSugarCaneHosts[8] = {0};
 static int gSugarCaneLabelCount = 0;
 static bool gSugarCaneShowBrightness = true;
 static bool gSugarCaneShowVolume = true;
@@ -65,8 +67,40 @@ static void sugarcane_remove_labels(void)
             r_msg2_main(gSugarCaneLabels[i], "removeFromSuperview", 0, 0, 0, 0);
         }
         gSugarCaneLabels[i] = 0;
+        gSugarCaneHosts[i] = 0;
     }
     gSugarCaneLabelCount = 0;
+}
+
+static bool sugarcane_read_percent(uint64_t host, int *percent)
+{
+    if (!r_is_objc_ptr(host) || !percent) return false;
+    float value = 0.0f;
+    bool ok = r_responds_main(host, "value") &&
+              r_msg2_main_struct_ret(host, "value", &value, sizeof(value),
+                                     NULL, 0, NULL, 0, NULL, 0, NULL, 0);
+    if (!ok && r_responds_main(host, "sliderValue")) {
+        ok = r_msg2_main_struct_ret(host, "sliderValue", &value, sizeof(value),
+                                    NULL, 0, NULL, 0, NULL, 0, NULL, 0);
+    }
+    if (!ok) return false;
+    if (value < 0.0f) value = 0.0f;
+    if (value > 1.0f) value = 1.0f;
+    *percent = (int)(value * 100.0f + 0.5f);
+    return true;
+}
+
+static void sugarcane_update_label(uint64_t label, uint64_t host)
+{
+    int percent = 0;
+    if (!r_is_objc_ptr(label) || !sugarcane_read_percent(host, &percent)) return;
+    char text[16] = {0};
+    snprintf(text, sizeof(text), "%d%%", percent);
+    uint64_t str = r_nsstr_retained(text);
+    if (r_is_objc_ptr(str)) {
+        r_msg2_main(label, "setText:", str, 0, 0, 0);
+        r_msg2_main(str, "release", 0, 0, 0, 0);
+    }
 }
 
 static uint64_t sugarcane_alloc_percent_label(uint64_t host, const char *text)
@@ -121,11 +155,16 @@ static void sugarcane_scan_sliders(uint64_t parent, int depth, int *hits)
     bool isSlider = strstr(cls, "Slider") != NULL;
     if (((isBrightness && gSugarCaneShowBrightness) || (isVolume && gSugarCaneShowVolume) ||
          (isSlider && (gSugarCaneShowBrightness || gSugarCaneShowVolume))) && gSugarCaneLabelCount < 8) {
-        const char *text = isVolume ? "50%" : "50%";
+        int percent = 0;
+        bool readValue = sugarcane_read_percent(parent, &percent);
+        char text[16] = "--%";
+        if (readValue) snprintf(text, sizeof(text), "%d%%", percent);
         uint64_t label = sugarcane_alloc_percent_label(parent, text);
         if (r_is_objc_ptr(label)) {
             r_msg2_main(parent, "addSubview:", label, 0, 0, 0);
-            gSugarCaneLabels[gSugarCaneLabelCount++] = label;
+            gSugarCaneLabels[gSugarCaneLabelCount] = label;
+            gSugarCaneHosts[gSugarCaneLabelCount] = parent;
+            gSugarCaneLabelCount++;
             if (hits) (*hits)++;
         }
     }
@@ -140,13 +179,22 @@ static void sugarcane_scan_sliders(uint64_t parent, int depth, int *hits)
 
 bool sugarcane_apply_in_session(void)
 {
-    printf("[SUGARCANE] apply\n");
+    int liveLabels = 0;
+    for (int i = 0; i < gSugarCaneLabelCount && i < 8; i++) {
+        uint64_t superview = r_is_objc_ptr(gSugarCaneLabels[i]) ?
+            r_msg2_main(gSugarCaneLabels[i], "superview", 0, 0, 0, 0) : 0;
+        if (r_is_objc_ptr(superview) && r_is_objc_ptr(gSugarCaneHosts[i])) {
+            sugarcane_update_label(gSugarCaneLabels[i], gSugarCaneHosts[i]);
+            liveLabels++;
+        }
+    }
+    if (liveLabels > 0) return true;
     sugarcane_remove_labels();
-    uint64_t win = sugarcane_key_window();
+    uint64_t win = sb_frontmost_window();
     if (!r_is_objc_ptr(win)) return false;
     int hits = 0;
     sugarcane_scan_sliders(win, 0, &hits);
-    printf("[SUGARCANE] added %d slider percent labels\n", hits);
+    if (hits > 0) printf("[SUGARCANE] added %d slider percent labels\n", hits);
     return hits > 0;
 }
 
@@ -168,6 +216,9 @@ void sugarcane_configure(bool showBrightness, bool showVolume, int fontSize)
 
 void sugarcane_forget_remote_state(void)
 {
-    for (int i = 0; i < 8; i++) gSugarCaneLabels[i] = 0;
+    for (int i = 0; i < 8; i++) {
+        gSugarCaneLabels[i] = 0;
+        gSugarCaneHosts[i] = 0;
+    }
     gSugarCaneLabelCount = 0;
 }

--- a/Infern0/tweaks/experimental_tweaks.h
+++ b/Infern0/tweaks/experimental_tweaks.h
@@ -42,6 +42,7 @@
 #import "experimental/pancake.h"
 #import "experimental/cylinderlite.h"
 #import "experimental/barmoji.h"
+#import "experimental/iconstyles.h"
 #import "experimental/blurrybadges.h"
 #import "experimental/snapper.h"
 #import "experimental/pullover.h"

--- a/Infern0/tweaks/gravitylite.m
+++ b/Infern0/tweaks/gravitylite.m
@@ -473,23 +473,17 @@ static uint64_t gl_overlay_for_list_view(uint64_t listView, GL_CGRect *overlayFr
 
 static uint64_t gl_overlay_for_list_view_ios26_legacy(uint64_t listView, GL_CGRect *overlayFrameOut)
 {
-    uint64_t window = gl_view_window(listView);
-    if (!r_is_objc_ptr(window)) return 0;
-
     GL_CGRect listBounds;
-    GL_CGRect overlayFrame;
     if (!gl_get_rect(listView, "bounds", &listBounds) || !gl_rect_valid(listBounds)) return 0;
-    if (!gl_convert_rect_to_view(listView, listBounds, window, &overlayFrame) ||
-        !gl_rect_valid(overlayFrame)) {
-        return 0;
-    }
-
-    uint64_t overlay = gl_view_with_frame(overlayFrame);
+    uint64_t overlay = gl_view_with_frame(listBounds);
     if (!r_is_objc_ptr(overlay)) return 0;
+    gl_set_integer(overlay, "setTag:", kGravityLiteOverlayTag);
     gl_set_bool(overlay, "setClipsToBounds:", true);
-    gl_set_bool(overlay, "setUserInteractionEnabled:", false);
-    r_msg2_main(window, "addSubview:", overlay, 0, 0, 0);
-    if (overlayFrameOut) *overlayFrameOut = overlayFrame;
+    gl_set_bool(overlay, "setUserInteractionEnabled:", true);
+    r_msg2_main(listView, "addSubview:", overlay, 0, 0, 0);
+    if (r_responds_main(listView, "bringSubviewToFront:"))
+        r_msg2_main(listView, "bringSubviewToFront:", overlay, 0, 0, 0);
+    if (overlayFrameOut) *overlayFrameOut = listBounds;
     return overlay;
 }
 
@@ -1072,6 +1066,7 @@ static bool gl_build_group_ios26_per_icon(uint64_t groups,
         if (!r_is_objc_ptr(frameValue)) continue;
 
         gl_reset_transform(icon);
+        gl_set_bool(icon, "setUserInteractionEnabled:", true);
         gl_array_add(liveItems, icon);
         gl_array_add(liveParents, parent);
         gl_array_add(liveFrames, frameValue);
@@ -1487,9 +1482,7 @@ bool gravitylite_apply_in_session(GravityLiteConfig config)
         return false;
     }
     int iosMajor = gl_remote_ios_major();
-    bool ios26Detected = iosMajor >= 26;
-    bool ios17Detected = iosMajor == 17;
-    bool useLiveIconPath = ios26Detected || ios17Detected;
+    bool useLiveIconPath = true;
     printf("[GRAVITY] Using iOS %d %s path.\n",
            iosMajor > 0 ? iosMajor : 0,
            useLiveIconPath
@@ -1550,17 +1543,16 @@ bool gravitylite_apply_in_session(GravityLiteConfig config)
             }
         }
 
-        for (int i = 0; i < count && !homeBuilt; i++) {
+        for (int i = 0; i < count; i++) {
             uint64_t listView = listViews[i];
             if (!r_is_objc_ptr(listView)) continue;
             if (gl_ptr_seen(listView, processed, processedCount)) continue;
 
             bool isDock = (dockListView && listView == dockListView);
             if (isDock) continue;
-            if (!gl_view_has_visible_window_rect(listView)) continue;
             if (processedCount < LV_CAP) processed[processedCount++] = listView;
 
-            printf("[GRAVITY] Capturing visible home screen page %d/%d...\n",
+            printf("[GRAVITY] Capturing discovered home screen page %d/%d...\n",
                    i + 1, count);
             if (gl_build_group(groups, listView, iconViewCls, config, false, true)) {
                 built++;

--- a/Infern0/tweaks/sb_walk.h
+++ b/Infern0/tweaks/sb_walk.h
@@ -22,4 +22,12 @@ int sb_collect_views_in_windows(uint64_t klass, uint64_t *out, int cap);
 // Bridge-only variant: BFS via the vphone bridge using a class name string.
 int sb_collect_views_in_windows_by_name(const char *className, uint64_t *out, int cap);
 
+// Collects UIApplication's windows in back-to-front order. This avoids the
+// deprecated -keyWindow path, which is commonly nil for SpringBoard scenes.
+int sb_collect_windows(uint64_t *out, int cap);
+
+// Returns the key window when one exists, otherwise the frontmost visible
+// UIApplication window.
+uint64_t sb_frontmost_window(void);
+
 #endif /* sb_walk_h */

--- a/Infern0/tweaks/sb_walk.m
+++ b/Infern0/tweaks/sb_walk.m
@@ -231,3 +231,43 @@ int sb_collect_views_in_windows(uint64_t klass, uint64_t *out, int cap)
     }
     return n;
 }
+
+int sb_collect_windows(uint64_t *out, int cap)
+{
+    if (!out || cap <= 0) return 0;
+    uint64_t clsApp = r_class("UIApplication");
+    if (!clsApp) return 0;
+    uint64_t app = sw_safe_msg(clsApp, "sharedApplication", 0, 0, 0, 0);
+    if (!app) return 0;
+
+    int n = 0;
+    uint64_t wins = sw_safe_msg(app, "windows", 0, 0, 0, 0);
+    if (wins) {
+        uint64_t count = r_msg(wins, r_sel("count"), 0, 0, 0, 0);
+        if (count > (uint64_t)cap) count = (uint64_t)cap;
+        for (uint64_t i = 0; i < count; i++) {
+            uint64_t win = r_msg(wins, r_sel("objectAtIndex:"), i, 0, 0, 0);
+            if (r_is_objc_ptr(win)) out[n++] = win;
+        }
+    }
+    if (n == 0) {
+        uint64_t key = sw_safe_msg(app, "keyWindow", 0, 0, 0, 0);
+        if (r_is_objc_ptr(key)) out[n++] = key;
+    }
+    return n;
+}
+
+uint64_t sb_frontmost_window(void)
+{
+    uint64_t windows[64] = {0};
+    int count = sb_collect_windows(windows, 64);
+    for (int i = count - 1; i >= 0; i--) {
+        uint64_t hidden = sw_safe_msg(windows[i], "isHidden", 0, 0, 0, 0);
+        if (!(hidden & 0xff)) return windows[i];
+    }
+    for (int i = 0; i < count; i++) {
+        uint64_t isKey = sw_safe_msg(windows[i], "isKeyWindow", 0, 0, 0, 0);
+        if (isKey & 0xff) return windows[i];
+    }
+    return count > 0 ? windows[count - 1] : 0;
+}

--- a/README.md
+++ b/README.md
@@ -1,306 +1,242 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/Nnnnnnn274/cyanide/main/Cyanide/Assets.xcassets/AppIcon.appiconset/infern0-icon-master.png" alt="infern0" width="160">
+  <img src="Infern0/Assets.xcassets/AppIcon.appiconset/infern0-icon-master.png" alt="infern0 app icon" width="152">
 </p>
 
 <h1 align="center">infern0</h1>
 
-## Project status
-
-**infern0** is maintained by `Nnnnnnn274`.
-
-## features
-AMFI bypass prob broken
-Coretrust bypass again broken
-kPAC hope it work
-
-## How to install
-Go to releases
-Download the latest ipa
-Intsall with and ipa installer not livecontainer
-
-## Discord
-
-https://discord.gg/fx3xvuUyj 
-
-## Goals
-
-Make tweaks more stable and continue the old unfinished tweaks.
-Make new tweaks and stuff.
-Add new exploits.
-And make the experience better!
-
-## The old README is here
-
-<details>
-<summary>Archived project README</summary>
-
 <p align="center">
-  <img src="https://raw.githubusercontent.com/zeroxjf/cyanide/main/Cyanide/Assets.xcassets/AppIcon.appiconset/icon-ios-1024x1024.png" alt="Cyanide" width="160">
+  A new chapter for the Cyanide project.<br>
+  Explore, configure, and run iOS tweaks from one open-source app.
 </p>
 
-<h1 align="center">Cyanide</h1>
+<p align="center">
+  <a href="https://github.com/Nnnnnnn274/Infern0/releases/latest">
+    <img alt="Latest release" src="https://img.shields.io/github/v/release/Nnnnnnn274/Infern0?style=flat-square&color=ef4444">
+  </a>
+  <img alt="Platform" src="https://img.shields.io/badge/platform-iOS%20%7C%20iPadOS-111827?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/current%20line-2.0-f97316?style=flat-square">
+  <a href="LICENSE">
+    <img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-2563eb?style=flat-square">
+  </a>
+</p>
 
-**By [@zeroxjf](https://github.com/zeroxjf)** — an iOS tweak runner built on top of the DarkSword kernel r/w primitive.
+<p align="center">
+  <a href="https://github.com/Nnnnnnn274/Infern0/releases/latest"><strong>Download</strong></a>
+  ·
+  <a href="https://github.com/Nnnnnnn274/Infern0/issues/new?template=bug_report.yml">Report a bug</a>
+  ·
+  <a href="https://github.com/Nnnnnnn274/Infern0/issues/new?template=feature_request.yml">Request a feature</a>
+  ·
+  <a href="https://discord.gg/fx3xvuUyj">Discord</a>
+</p>
 
-Cyanide is a fork of [`wh1te4ever/darksword-kexploit-fun`](https://github.com/wh1te4ever/darksword-kexploit-fun)
-for iOS kernel research. It wraps the native DarkSword kernel stages in an
-Objective-C iOS app, restructures the UI as an Installer/Settings split, and
-adds a few reliability fixes for repeated local testing. It does not ship
-the browser-delivered WebKit/dyld parts of the original DarkSword chain.
+---
 
-## Project Status
+## A fresh start
 
-As of v1.3.6, Patreon integration has been removed. All installable Cyanide
-tweaks are free and no tweak access depends on account linking.
+**infern0** is the active continuation of Cyanide, maintained by
+[@Nnnnnnn274](https://github.com/Nnnnnnn274). The goal is simple: preserve the
+research and creativity behind the original project, finish its incomplete
+ideas, and build a cleaner and more dependable tweak-running experience.
 
-Previously unreleased work-in-progress tweak code has been opened under the
-same AGPL-3.0 license as the rest of the project. Some unfinished entries remain
-visible in the app so contributors can find them, but installation stays
-disabled until someone finishes and verifies them.
+This is not a traditional jailbreak. infern0 uses the DarkSword kernel
+read/write foundation and RemoteCall to apply supported changes from a
+sideloaded app. Many visual tweaks live only for the active session; a smaller
+set intentionally modifies persistent files and is clearly marked in the app.
 
-`zeroxjf` is stepping away from active Cyanide development. The code is now
-open under AGPL-3.0 so anyone can fork it, study it, reuse it, or continue it
-under the license terms.
+> [!IMPORTANT]
+> infern0 is experimental system software. A tweak can crash SpringBoard,
+> disturb the Home Screen layout, partially apply, or stop working after an iOS
+> update. Read each package warning, keep backups, and test responsibly.
+
+## What we are building
+
+| Area | Highlights |
+| --- | --- |
+| **Home Screen** | SBCustomizer, Gravity Lite, Cylinder Lite, Rounded Icons, Watch Layout, labels, badges, themes, and layout controls |
+| **Status Bar** | StatBar, NSBar, NiceBar Lite, Signal Readouts, carrier text, and live system information |
+| **Control Center** | Layout, spacing, appearance, status, haptics, and security experiments |
+| **Theming** | Cyanide Themer, SnowBoard Lite imports, icon styles, and LiveWP |
+| **System tools** | Powercuff, OTA controls, Watch pairing overrides, location simulation, IPA tools, and carefully labeled persistent changes |
+| **Extensibility** | QuickLoader for local JavaScript tweaks and source repositories for installable community tweaks |
+
+### New Home Screen work
+
+- **Rounded Icons** applies smooth, configurable corners to every discovered
+  Home Screen icon without requiring a theme.
+- **Watch Layout** creates a compact Apple Watch-style grid with circular,
+  pressable icons and reversible layout changes.
+- **Gravity Lite** runs physics on live icon views across discovered pages so
+  icons remain interactive.
+- **Cylinder Lite** applies perspective depth across the Home Screen while
+  preserving normal icon taps.
+- **Barmoji** now presents real pressable emoji buttons with highlight and
+  selection feedback. Its enabled preference survives reboot and the overlay is
+  recreated with the next infern0 SpringBoard session. Cross-process text
+  insertion into arbitrary app keyboards is still a work in progress.
+
+## Project status
+
+infern0 2.0 is an active reboot, not a promise that every experiment is
+finished. Work is currently focused on:
+
+- making existing tweaks configurable and easier to restore;
+- keeping icons and controls interactive after visual transformations;
+- applying Home Screen tweaks consistently across all discovered pages;
+- producing useful activity logs for setup, apply, refresh, and cleanup;
+- finishing older Cyanide experiments without hiding their limitations;
+- improving exploit and RemoteCall reliability across supported targets.
+
+The AMFI, CoreTrust, and kPAC paths remain research-heavy and may be incomplete
+or unreliable on some devices. Their presence in the source tree should not be
+read as a universal compatibility guarantee.
+
+## Compatibility
+
+The app currently gates tweak execution to:
+
+- iOS/iPadOS **17.0 through 18.7.1**
+- iOS/iPadOS **26.0 through 26.0.1**
+
+The kernel issues used by this project, <code>CVE-2025-43510</code> and
+<code>CVE-2025-43520</code>, were fixed in iOS/iPadOS 18.7.2 and 26.1. Later
+releases are outside the current exploit window. A19 and M5 devices are not
+supported.
+
+Compatibility inside those ranges can still vary by device and tweak. Check
+the package description and activity log before assuming a feature is safe for
+your setup.
 
 ## Install
 
-Open this page on your iPhone/iPad and tap one of the buttons below.
+1. Open the [latest release](https://github.com/Nnnnnnn274/Infern0/releases/latest).
+2. Download the current <code>.ipa</code>.
+3. Install it with a normal IPA sideloading or signing tool.
+4. Launch infern0, review the compatibility warning, and configure tweaks before
+   adding them to the queue.
 
-<p align="center">
-  <a href="https://celloserenity.github.io/altdirect/?url=https://raw.githubusercontent.com/zeroxjf/cyanide/main/source.json" target="_blank">
-    <img src="https://github.com/CelloSerenity/altdirect/blob/main/assets/png/AltSource_Blue.png?raw=true" alt="Add AltSource" width="200">
-  </a>
-  <a href="https://github.com/zeroxjf/cyanide/releases/latest" target="_blank">
-    <img src="https://github.com/CelloSerenity/altdirect/blob/main/assets/png/Download_Blue.png?raw=true" alt="Download .ipa" width="200">
-  </a>
-</p>
+Do **not** run infern0 through LiveContainer. The exploit and process behavior
+expect a normally installed application.
 
-## Feedback
+## How tweak state works
 
-- [Report a bug](https://github.com/zeroxjf/cyanide/issues/new?template=bug_report.yml)
-- [Request a feature](https://github.com/zeroxjf/cyanide/issues/new?template=feature_request.yml)
-- [Join the Signal group](https://signal.group/#CjQKIP0pxjc9V52ddCNk--04DosuoQl-vVOsznJfQ4GwlrlxEhCveFhBS8YdNcILpUFt7IqC) for setup help, support,
-  test notes, and rough ideas before they become issues.
+infern0 deliberately separates different kinds of changes:
 
-## Beta Tweaks
+- **Live session tweaks** run through RemoteCall and generally need infern0's
+  SpringBoard session to remain active. A respring restores stock behavior.
+- **Saved preferences** survive app relaunches and reboots, then control what
+  infern0 recreates during a later session.
+- **Persistent changes** write system-accessible files and remain until their
+  documented restore action is used. These packages carry stronger warnings.
 
-Beta tweaks are free and visible without account linking. They are unstable and
-intended for testers who are comfortable with SpringBoard glitches, crashes, or
-partial behavior.
+The Settings screen exposes per-tweak controls, current intent/applied state,
+cleanup behavior, and a detailed activity log. If something behaves
+unexpectedly, save that log before restarting the app.
 
-## Tweaks
+## Build from source
 
-These tweaks have been tested on iOS 18.x and 26.x. Expect version drift in
-SpringBoard and related daemons to break things on other releases.
+Requirements:
 
-### Status Bar
+- macOS with a compatible Xcode and iPhoneOS SDK;
+- command-line build tools;
+- <code>xcbeautify</code> is optional—the build script falls back to raw
+  <code>xcodebuild</code> output.
 
-- **StatBar**: battery temperature and free-RAM overlay anchored to the
-  SpringBoard status bar, with optional C/F and network-speed display.
-- **NSBar**: compact live download/upload speed overlay for the status bar,
-  with selectable corner/center positions. Ported from
-  [`d1y/cyanide-ios`](https://github.com/d1y/cyanide-ios).
-- **NiceBar Lite**: configurable status-bar-adjacent labels for custom text,
-  date/time formats, battery, memory, traffic, uptime, IP address, disk,
-  thermal state, and other live readouts. Ported from
-  [`d1y/cyanide-ios`](https://github.com/d1y/cyanide-ios).
-- **Signal Readouts**: RSRP dBm on cellular, bar count on WiFi. Replaces
-  signal-strength glyphs with live numeric readouts.
+Build an unsigned IPA:
 
-### Home Screen Layout
-
-- **SBCustomizer**: dock icon count, home-screen columns/rows, and hidden icon
-  labels.
-- **Home Layout Extras**: extra padding around the home grid and dock, plus
-  per-icon scale for home and dock icons. Stacks on top of SBCustomizer.
-
-### Performance
-
-- **Powercuff**: CPU/GPU underclocking through simulated `thermalmonitord`
-  pressure levels (off, nominal, light, moderate, heavy). Lasts until reboot.
-  Port of [`rpetrich/Powercuff`](https://github.com/rpetrich/Powercuff).
-
-### SpringBoard Tweaks
-
-Ported from [`kolbicz/DarkSword-Tweaks`](https://github.com/kolbicz/DarkSword-Tweaks):
-
-- **Disable App Library**: removes the App Library page past the last home screen.
-- **Disable Icon Fly-In**: skips the spring-in animation when icons appear.
-- **Zero Wake Animation**: snaps the display on instantly when waking.
-- **Zero Backlight Fade**: instant lock/unlock backlight.
-- **Double-Tap to Lock**: lock the device with a wallpaper double-tap.
-
-### System Updates
-
-- **Disable OTA Updates**: toggles the launchd OTA `disabled.plist` to block or
-  unblock update prompts. Persists across reboots.
-
-### Beta
-
-> ⚠︎ Work in progress — these may crash SpringBoard, glitch layout, work only
-> partially, or need re-applying between builds.
-
-- **Gravity Lite**: core port of Julio Verne's classic Gravity tweak. Applies
-  UIDynamicAnimator physics to home-screen and dock icons — gravity, collisions,
-  bounce, friction, accelerometer steering, shake pulses, and an explosion
-  button. Use Restore Icon Layout if icons stay displaced after deactivating.
-- **Axon Lite**: groups Notification Center requests by app with a SpringBoard
-  overlay and dedups duplicates while the RemoteCall session is alive.
-- **Dynamic Stage Lite**: brings Stage Manager-style split-view to iPhone over
-  RemoteCall — no jailbreak required. Hosts a second app's scene alongside
-  SpringBoard using the same scene-hosting design as [`tomt000`'s Dynamic Stage](https://havoc.app/package/dynamicstage).
-- **FastLockX Lite**: keeps Face ID retry/unlock requests armed through
-  SpringBoard timers so pickup-to-unlock can work after Cyanide closes.
-- **TypeBanner**: port of TypeMillennium. Shows a pill banner just below the
-  Dynamic Island when imagent reports an active iMessage typing indicator.
-- **Notification Island**: mirrors incoming banners into the Dynamic Island
-  using ActivityKit Live Activities.
-- **Cyanide Themer**: per-bundle icon theme engine. Walks SpringBoard's
-  SBIconView hierarchy and swaps each icon's image with a PNG matched on bundle
-  ID. Ships with iOS 6 Theme; also accepts a custom folder of `<bundleID>.png`
-  files or a binary plist. Pick a theme in Settings before running.
-- **SnowBoard Lite**: imports SnowBoard/IconBundles-style theme folders or
-  archives into Cyanide's local theme library, then applies the selected theme
-  through the existing icon replacement pipeline. Ported from
-  [`d1y/cyanide-ios`](https://github.com/d1y/cyanide-ios).
-- **LiveWP**: copies a selected MP4/MOV/M4V into Cyanide's app container and
-  plays it behind SpringBoard's home and lock screen windows while the live
-  RemoteCall session is active. Ported from
-  [`d1y/cyanide-ios`](https://github.com/d1y/cyanide-ios).
-- **Watch Pairing Override**: edits the watchOS pairing range stored on the
-  iPhone so you can pair a newer Apple Watch or revive an older one. Persists
-  across reboots; respring before pairing.
-- **Location Simulator**: drives Apple's CoreLocation simulation path from a
-  RemoteCall host process and sets a static target coordinate. Simulated
-  locations may violate app terms, platform rules, game rules, ride-share or
-  delivery policies, or local law depending on how they are used. Use only where
-  you have permission; you are responsible for your use and apply or restore it
-  at your own risk. It may also affect location-tied system behavior such as
-  time zone/date/time handling and can have unintended consequences; only use it
-  if you know what you're doing. Credits: `kolbicz` provided the
-  RemoteCall/CLSimulationManager GPS spoofer prototype, and `ezzuldinSt`'s
-  LSpoof provided the app-side spoofing, picker, bookmarks, and route-simulation
-  reference.
-- **Call Recording Sound**: replaces the CallServices
-  `StartDisclosureWithTone` and `StopDisclosure` audio files with Cyanide's
-  bundled silent payloads, with separate Silence and Restore actions. Cyanide
-  backs up the first originals into its app container before replacement, but
-  this is still a persistent system-file edit under
-  `/var/mobile/Library/CallServices/Greetings/default`. Disclosure sounds may be
-  legally required where you live; you are responsible for your use and should
-  restore the originals before removing Cyanide if you want Cyanide's backups
-  written back. Credits: `YangJiiii` (`@duongduong0908`) for the EnsWilde and
-  Disable Call Recording BookRestore reference tools, and `@Little_34306` as
-  credited by the original projects for the Disable Call Recording concept.
-
-### System
-
-- **Disable OTA Updates**: toggles the launchd OTA `disabled.plist` to block or
-  unblock update prompts. Persists across reboots.
-- **IPA Decryptor**: local IPA decryptor for App Store apps. Includes app discovery, 
-  encryption probing, and basic IPA rebuilding. Full memory decryption requires KRW integration.
-
-## Supported Targets
-
-Tested target range:
-
-- iOS/iPadOS 17.0 through 18.7.1
-- iOS/iPadOS 26.0 through 26.0.1
-- A19/M5 devices are not supported
-
-The kernel bugs used here, `CVE-2025-43510` and `CVE-2025-43520`, were fixed in
-iOS/iPadOS 18.7.2 and 26.1. Later builds are outside this kernel exploit window.
-
-## What This Fork Changes
-
-- Cleans shared exploit state before each attempt.
-- Matches the target process with an explicit marker.
-- Validates sockets before using the spray path.
-- Treats missed races as retryable failures instead of hard failures.
-- Tightens the A18/M4 `pe_v2` path with initialized target-file contents,
-  stable local remap addresses, bounded page freeing, socket-spray preflight
-  checks, and controlled zone-trim retries.
-
-## Kernel Research Features
-
-- Escape the app sandbox.
-- Control or crash userspace processes from the app.
-- Change UID, GID, and sticky bits on target files.
-- Disable ASLR by setting `P_DISABLE_ASLR` in `launchd`'s `proc->p_flag`.
-
-## Credits
-
-- [`opa334`](https://github.com/opa334): original [`darksword-kexploit`](https://github.com/opa334/darksword-kexploit), ChOma, and XPF — the kernel r/w primitive Cyanide is built on.
-- [`wh1te4ever`](https://github.com/wh1te4ever): [`kfun` / `darksword-kexploit-fun`](https://github.com/wh1te4ever/darksword-kexploit-fun) — the RemoteCall implementation that lets a sideloaded app apply tweaks inside SpringBoard. Cyanide is a fork of this project.
-- [`rooootdev`](https://github.com/rooootdev): working kexploit behavior used to stabilize this fork.
-- [`neonmodder123`](https://github.com/neonmodder123): Web Respring method.
-- [`kolbicz`](https://github.com/kolbicz): OTA Disabler, SpringBoard tweaks, and
-  the RemoteCall/CLSimulationManager GPS spoofer prototype used as the starting
-  point for Location Simulator.
-- `ezzuldinSt`: LSpoof app-side `CLLocationManager` spoofing, picker,
-  bookmarks, and route-simulation reference used while shaping Location
-  Simulator.
-- `YangJiiii` (`@duongduong0908`): EnsWilde and Disable Call Recording
-  BookRestore reference tools used while shaping Call Recording Sound.
-- `@Little_34306`: credited by the original call-recording projects for the
-  Disable Call Recording concept.
-- [`rpetrich`](https://github.com/rpetrich): Powercuff.
-- [Julio Verne](https://github.com/julioverne): the original [Gravity](https://github.com/julioverne/Gravity) tweak that Gravity Lite is a core port of.
-- [`d1y`](https://x.com/chenhonzhou): [`cyanide-ios`](https://github.com/d1y/cyanide-ios)
-  AGPL-3.0 sources used for the NSBar, NiceBar Lite, SnowBoard Lite, and
-  LiveWP ports.
-- [`tomt000`](https://github.com/tomt000): [Dynamic Stage](https://havoc.app/package/dynamicstage) — the original Stage Manager-for-iPhone tweak whose split-view + scene-hosting design Dynamic Stage Lite re-implements over RemoteCall.
-
-### UI inspiration
-
-- The classic [Installer.app](https://github.com/AppTapp/Installer-3) (Ripdev & Nullriver Software, now maintained by AppTapp and the Legacy Jailbreak community) — the iPhoneOS 1 package-manager look that the Cyanide Installer tab is modeled after.
-- The [Sileo Project](https://github.com/Sileo/Sileo) (the Sileo Team) — the queue → review → confirm install flow and the bottom queue-popup pattern.
-
-## Build
-
-```sh
+~~~sh
 ./scripts/build.sh
-```
+~~~
 
-The build script uses the `Cyanide` scheme, disables code signing, and writes
-an unsigned IPA to:
+The default build uses the <code>Infern0</code> scheme and writes:
 
-```text
-build/Cyanide.ipa
-```
+~~~text
+build/Infern0.ipa
+~~~
 
 Equivalent manual build:
 
-```sh
+~~~sh
 xcodebuild \
-  -project Cyanide.xcodeproj \
-  -scheme Cyanide \
+  -project Infern0.xcodeproj \
+  -scheme Infern0 \
   -sdk iphoneos \
   -configuration Debug \
   CODE_SIGNING_ALLOWED=NO \
   build
-```
+~~~
+
+Release notes for completed and upcoming work live in
+[RELEASE_NOTES.md](RELEASE_NOTES.md).
+
+## Contributing
+
+Bug reports, test results, documentation fixes, and focused tweak improvements
+are welcome.
+
+Before opening an issue:
+
+1. confirm that the device and OS are in the supported range;
+2. reproduce with as few enabled tweaks as possible;
+3. restore the affected tweak and try once more;
+4. attach the infern0 activity log and exact device/iOS information;
+5. explain whether the problem happens on Apply, refresh, cleanup, respring, or
+   reboot.
+
+Use the repository templates to
+[report a bug](https://github.com/Nnnnnnn274/Infern0/issues/new?template=bug_report.yml)
+or
+[propose a feature](https://github.com/Nnnnnnn274/Infern0/issues/new?template=feature_request.yml).
+
+## Community
+
+- [Discord](https://discord.gg/fx3xvuUyj)
+- [Signal support and testing group](https://signal.group/#CjQKIP0pxjc9V52ddCNk--04DosuoQl-vVOsznJfQ4GwlrlxEhCveFhBS8YdNcILpUFt7IqC)
+- [GitHub issues](https://github.com/Nnnnnnn274/Infern0/issues)
+
+## Project lineage and credits
+
+infern0 stands on substantial work from the iOS research and tweak communities:
+
+- [zeroxjf](https://github.com/zeroxjf) created Cyanide and its
+  Installer/Settings direction.
+- [opa334](https://github.com/opa334) created
+  [darksword-kexploit](https://github.com/opa334/darksword-kexploit), ChOma,
+  and XPF.
+- [wh1te4ever](https://github.com/wh1te4ever) created
+  [darksword-kexploit-fun](https://github.com/wh1te4ever/darksword-kexploit-fun)
+  and the RemoteCall foundation used by this project.
+- [rooootdev](https://github.com/rooootdev) contributed exploit behavior used
+  while stabilizing the fork.
+- [kolbicz](https://github.com/kolbicz) contributed DarkSword tweaks, OTA work,
+  and the original RemoteCall location-simulation prototype.
+- [rpetrich](https://github.com/rpetrich) created Powercuff.
+- [Julio Verne](https://github.com/julioverne) created the original Gravity
+  tweak.
+- [d1y](https://github.com/d1y) published the AGPL-3.0
+  [cyanide-ios](https://github.com/d1y/cyanide-ios) sources adapted by several
+  ports in this tree.
+- [tomt000](https://github.com/tomt000) created Dynamic Stage, whose
+  scene-hosting design inspired Dynamic Stage Lite.
+- <code>ezzuldinSt</code>, <code>YangJiiii</code>,
+  <code>@Little_34306</code>, <code>neonmodder123</code>, and the many testers
+  and contributors credited in package descriptions helped shape individual
+  tools and ports.
+
+The interface also takes inspiration from classic
+[Installer.app](https://github.com/AppTapp/Installer-3) and
+[Sileo](https://github.com/Sileo/Sileo).
 
 ## License
 
-This repository is licensed under **AGPL-3.0**. See `LICENSE`.
+infern0 is distributed under the
+[GNU Affero General Public License v3.0](LICENSE).
 
-The NSBar, NiceBar Lite, SnowBoard Lite, and LiveWP ports adapt AGPL-3.0 code
-from [`d1y/cyanide-ios`](https://github.com/d1y/cyanide-ios) and remain in the
-AGPL-covered tree.
+Fork it, study it, improve it, and keep covered changes open under the same
+license. This project is provided without warranty.
 
-## JavaScript Tweaks
+---
 
-Cyanide includes two JavaScript tweak runners contributed by Iggy05:
-
-- **QuickLoader** imports a local `.js` file from Files and exposes declared
-  `@param` values as settings rows.
-- **RepoTweaks Store** imports HTTPS JSON repositories and downloads selected
-  JavaScript tweaks from those sources. Cyanide seeds the zeroxjf source at
-  `https://zeroxjf.github.io/cyanide-repotweaks.json` by default.
-
-Only run scripts and repositories you trust; JavaScript tweaks can call Cyanide
-RemoteCall helpers and may destabilize SpringBoard if the script is buggy.
-
-
-</details>
+<p align="center">
+  <strong>infern0 is where Cyanide continues—cleaner, more open, and moving forward.</strong>
+</p>


### PR DESCRIPTION
## What changed

- added per-tweak settings, configuration summaries, cleanup state, and detailed activity logging
- made Gravity Lite and Cylinder Lite process every discovered Home Screen page while preserving live icon interaction
- replaced Barmoji's static strip with pressable emoji buttons and selection feedback
- added configurable Rounded Icons and Watch Layout packages with live refresh and restoration support
- improved shared SpringBoard view walking for newer experimental tweaks
- redesigned the README as the infern0 2.0 project landing page

## Why

Several experimental tweaks only styled the first visible page or used non-interactive presentation views. Their settings and logs also did not explain enough about apply, refresh, cleanup, or persistence behavior. The README still presented infern0 as a temporary continuation rather than the project's active new direction.

## Impact

Home Screen transformations now cover all discovered pages and keep normal icon taps available. Users get clearer controls, restore behavior, and diagnostic logs. New visitors get current installation, compatibility, contribution, and project-lineage information.

## Validation

- `git diff --cached --check`
- static routing audit for package sections, run accounting, cleanup registration, and new tweak exports
- source brace-balance checks
- README asset and local-link existence checks

An iOS/Xcode build was not available in the Windows workspace.
