### PR TITLE
Add configurable Home and Lock Screen tweak ports

### DIFF
--- a/Infern0/SettingsViewController.h
+++ b/Infern0/SettingsViewController.h
@@ -100,6 +100,8 @@ extern NSString * const kSettingsCylinderLiteEnabled;
 extern NSString * const kSettingsBarmojiEnabled;
 extern NSString * const kSettingsRoundedIconsEnabled;
 extern NSString * const kSettingsWatchLayoutEnabled;
+extern NSString * const kSettingsLockCustomizerEnabled;
+extern NSString * const kSettingsFreePlacementEnabled;
 extern NSString * const kSettingsBlurryBadgesEnabled;
 extern NSString * const kSettingsSnapperEnabled;
 extern NSString * const kSettingsPullOverEnabled;

--- a/Infern0/SettingsViewController.m
+++ b/Infern0/SettingsViewController.m
@@ -855,6 +855,11 @@ NSString * const kSettingsSBCDockIcons  = @"SBCDockIcons";
 NSString * const kSettingsSBCCols       = @"SBCCols";
 NSString * const kSettingsSBCRows       = @"SBCRows";
 NSString * const kSettingsSBCHideLabels = @"SBCHideLabels";
+static NSString * const kSettingsSBCHideBadges = @"SBCHideBadges";
+static NSString * const kSettingsSBCHidePageDots = @"SBCHidePageDots";
+static NSString * const kSettingsSBCHideFolderBackground = @"SBCHideFolderBackground";
+static NSString * const kSettingsSBCHideDockBackground = @"SBCHideDockBackground";
+static NSString * const kSettingsSBCIconAlphaPct = @"SBCIconAlphaPct";
 
 NSString * const kSettingsPowercuffEnabled = @"PowercuffEnabled";
 NSString * const kSettingsPowercuffLevel   = @"PowercuffLevel";
@@ -877,6 +882,8 @@ NSString * const kSettingsLayoutHomeExtraBottom = @"LayoutHomeExtraBottom";
 NSString * const kSettingsLayoutDockExtraHorizontal = @"LayoutDockExtraHorizontal";
 NSString * const kSettingsLayoutHomeScalePct    = @"LayoutHomeScalePct";
 NSString * const kSettingsLayoutDockScalePct    = @"LayoutDockScalePct";
+static NSString * const kSettingsLayoutApplyHomeControls = @"LayoutApplyHomeControls";
+static NSString * const kSettingsLayoutApplyDockControls = @"LayoutApplyDockControls";
 
 static double settings_number_row_normalized_value(NSDictionary *row, double value)
 {
@@ -1052,11 +1059,24 @@ static NSString * const kSettingsRoundedIconsRadius = @"RoundedIconsRadius";
 NSString * const kSettingsWatchLayoutEnabled = @"WatchLayoutEnabled";
 static NSString * const kSettingsWatchLayoutCompactPct = @"WatchLayoutCompactPct";
 static NSString * const kSettingsWatchLayoutScalePct = @"WatchLayoutScalePct";
+NSString * const kSettingsLockCustomizerEnabled = @"LockCustomizerEnabled";
+static NSString * const kSettingsLockCustomizerClockScalePct = @"LockCustomizerClockScalePct";
+static NSString * const kSettingsLockCustomizerXOffset = @"LockCustomizerXOffset";
+static NSString * const kSettingsLockCustomizerYOffset = @"LockCustomizerYOffset";
+static NSString * const kSettingsLockCustomizerHideQuickActions = @"LockCustomizerHideQuickActions";
+static NSString * const kSettingsLockCustomizerHidePageDots = @"LockCustomizerHidePageDots";
+static NSString * const kSettingsLockCustomizerContentAlphaPct = @"LockCustomizerContentAlphaPct";
+NSString * const kSettingsFreePlacementEnabled = @"FreePlacementEnabled";
+static NSString * const kSettingsFreePlacementHorizontalStep = @"FreePlacementHorizontalStep";
+static NSString * const kSettingsFreePlacementVerticalStep = @"FreePlacementVerticalStep";
+static NSString * const kSettingsFreePlacementStaggerPct = @"FreePlacementStaggerPct";
 NSString * const kSettingsBlurryBadgesEnabled = @"BlurryBadgesEnabled";
 static NSString * const kSettingsBlurryBadgesRed = @"BlurryBadgesRed";
 static NSString * const kSettingsBlurryBadgesGreen = @"BlurryBadgesGreen";
 static NSString * const kSettingsBlurryBadgesBlue = @"BlurryBadgesBlue";
 static NSString * const kSettingsBlurryBadgesAlphaPct = @"BlurryBadgesAlphaPct";
+static NSString * const kSettingsBlurryBadgesGrowEnabled = @"BlurryBadgesGrowEnabled";
+static NSString * const kSettingsBlurryBadgesMaxScalePct = @"BlurryBadgesMaxScalePct";
 NSString * const kSettingsSnapperEnabled = @"SnapperEnabled";
 static NSString * const kSettingsSnapperX = @"SnapperX";
 static NSString * const kSettingsSnapperY = @"SnapperY";
@@ -1573,6 +1593,18 @@ static bool settings_stop_roundedicons_registered(BOOL springboardWillDie)
     return roundedicons_stop_in_session();
 }
 
+static bool settings_stop_lockcustomizer_registered(BOOL springboardWillDie)
+{
+    (void)springboardWillDie;
+    return lockcustomizer_stop_in_session();
+}
+
+static bool settings_stop_freeplacement_registered(BOOL springboardWillDie)
+{
+    (void)springboardWillDie;
+    return freeplacement_stop_in_session();
+}
+
 static bool settings_stop_watchlayout_registered(BOOL springboardWillDie)
 {
     (void)springboardWillDie;
@@ -1670,7 +1702,9 @@ static void settings_each_springboard_cleanup_entry(void (^block)(const Settings
         { kSettingsCylinderLiteEnabled, "Cylinder Lite", NULL, settings_stop_cylinderlite_registered, cylinderlite_forget_remote_state, NULL, YES, YES },
         { kSettingsBarmojiEnabled, "Barmoji", NULL, settings_stop_barmoji_registered, barmoji_forget_remote_state, NULL, YES, YES },
         { kSettingsRoundedIconsEnabled, "Rounded Icons", NULL, settings_stop_roundedicons_registered, roundedicons_forget_remote_state, NULL, YES, YES },
+        { kSettingsFreePlacementEnabled, "Free Placement Lite", NULL, settings_stop_freeplacement_registered, freeplacement_forget_remote_state, NULL, YES, YES },
         { kSettingsWatchLayoutEnabled, "Watch Layout", NULL, settings_stop_watchlayout_registered, watchlayout_forget_remote_state, NULL, YES, YES },
+        { kSettingsLockCustomizerEnabled, "Lock Screen Customizer", NULL, settings_stop_lockcustomizer_registered, lockcustomizer_forget_remote_state, NULL, YES, YES },
         { kSettingsBlurryBadgesEnabled, "BlurryBadges", NULL, settings_stop_blurrybadges_registered, blurrybadges_forget_remote_state, NULL, YES, YES },
         { kSettingsSnapperEnabled, "Snapper", NULL, settings_stop_snapper_registered, snapper_forget_remote_state, NULL, YES, YES },
         { kSettingsPullOverEnabled, "PullOver", NULL, settings_stop_pullover_registered, pullover_forget_remote_state, NULL, YES, YES },
@@ -3360,12 +3394,40 @@ void settings_destroy_springboard_remote_call(void)
 
 static bool settings_apply_sbc_from_defaults_locked(NSUserDefaults *d)
 {
-    if (![d boolForKey:kSettingsSBCEnabled]) return false;
+    if (![d boolForKey:kSettingsSBCEnabled]) {
+        NSInteger oldAlpha = [d objectForKey:kSettingsSBCIconAlphaPct] ? [d integerForKey:kSettingsSBCIconAlphaPct] : 100;
+        BOOL hadAppearanceChanges = [d boolForKey:kSettingsSBCHideBadges] ||
+                                    [d boolForKey:kSettingsSBCHidePageDots] ||
+                                    [d boolForKey:kSettingsSBCHideFolderBackground] ||
+                                    [d boolForKey:kSettingsSBCHideDockBackground] || oldAlpha != 100;
+        if (hadAppearanceChanges) homecustom_stop_in_session();
+        printf("[SBCUSTOMIZER] disabled; atriaExtrasRestored=%d\n", hadAppearanceChanges);
+        return false;
+    }
 
-    return sbcustomizer_apply_in_session((int)[d integerForKey:kSettingsSBCDockIcons],
-                                         (int)[d integerForKey:kSettingsSBCCols],
-                                         (int)[d integerForKey:kSettingsSBCRows],
-                                         [d boolForKey:kSettingsSBCHideLabels]);
+    NSInteger iconAlpha = [d objectForKey:kSettingsSBCIconAlphaPct] ? [d integerForKey:kSettingsSBCIconAlphaPct] : 100;
+    homecustom_configure([d boolForKey:kSettingsSBCHideBadges],
+                         [d boolForKey:kSettingsSBCHidePageDots],
+                         [d boolForKey:kSettingsSBCHideFolderBackground],
+                         [d boolForKey:kSettingsSBCHideDockBackground],
+                         (int)iconAlpha);
+    bool layoutOK = sbcustomizer_apply_in_session((int)[d integerForKey:kSettingsSBCDockIcons],
+                                                  (int)[d integerForKey:kSettingsSBCCols],
+                                                  (int)[d integerForKey:kSettingsSBCRows],
+                                                  [d boolForKey:kSettingsSBCHideLabels]);
+    bool appearanceOK = homecustom_apply_in_session();
+    printf("[SBCUSTOMIZER] layout=%d atriaExtras=%d\n", layoutOK, appearanceOK);
+    log_user("[SBCUSTOMIZER] dock=%ld grid=%ldx%ld labelsHidden=%d badgesHidden=%d pageDotsHidden=%d folderBackgroundHidden=%d dockBackgroundHidden=%d iconOpacity=%ld%% layoutResult=%d appearanceResult=%d.\n",
+             (long)[d integerForKey:kSettingsSBCDockIcons],
+             (long)[d integerForKey:kSettingsSBCCols],
+             (long)[d integerForKey:kSettingsSBCRows],
+             [d boolForKey:kSettingsSBCHideLabels],
+             [d boolForKey:kSettingsSBCHideBadges],
+             [d boolForKey:kSettingsSBCHidePageDots],
+             [d boolForKey:kSettingsSBCHideFolderBackground],
+             [d boolForKey:kSettingsSBCHideDockBackground],
+             (long)iconAlpha, layoutOK, appearanceOK);
+    return layoutOK || appearanceOK;
 }
 
 static NSString *settings_nicebar_key(NSString *prefix, NSInteger slot)
@@ -3887,8 +3949,14 @@ static bool settings_apply_layout_extras_from_defaults_locked(NSUserDefaults *d)
     double dockExH = (double)[d integerForKey:kSettingsLayoutDockExtraHorizontal];
     NSInteger hsPct = [d integerForKey:kSettingsLayoutHomeScalePct];
     NSInteger dkPct = [d integerForKey:kSettingsLayoutDockScalePct];
+    BOOL applyHome = [d objectForKey:kSettingsLayoutApplyHomeControls] ? [d boolForKey:kSettingsLayoutApplyHomeControls] : YES;
+    BOOL applyDock = [d objectForKey:kSettingsLayoutApplyDockControls] ? [d boolForKey:kSettingsLayoutApplyDockControls] : YES;
+    if (!applyHome) { exL = 0; exR = 0; exT = 0; exB = 0; hsPct = 100; }
+    if (!applyDock) { dockExH = 0; dkPct = 100; }
     double homeScale = (hsPct > 0) ? (double)hsPct / 100.0 : 1.0;
     double dockScale = (dkPct > 0) ? (double)dkPct / 100.0 : 1.0;
+    log_user("[HOME EXTRAS] homeControls=%d dockControls=%d insets=%.0f/%.0f/%.0f/%.0f dockExtra=%.0f scales=%.0f%%/%.0f%%.\n",
+             applyHome, applyDock, exL, exR, exT, exB, dockExH, homeScale * 100.0, dockScale * 100.0);
     return darksword_layout_apply_in_session(exL, exR, exT, exB, dockExH, homeScale, dockScale);
 }
 
@@ -4277,6 +4345,11 @@ static void settings_reset_sbc_defaults(void)
     [d setInteger:kSBCDefaultCols forKey:kSettingsSBCCols];
     [d setInteger:kSBCDefaultRows forKey:kSettingsSBCRows];
     [d setBool:kSBCDefaultHideLabels forKey:kSettingsSBCHideLabels];
+    [d setBool:NO forKey:kSettingsSBCHideBadges];
+    [d setBool:NO forKey:kSettingsSBCHidePageDots];
+    [d setBool:NO forKey:kSettingsSBCHideFolderBackground];
+    [d setBool:NO forKey:kSettingsSBCHideDockBackground];
+    [d setInteger:100 forKey:kSettingsSBCIconAlphaPct];
     [d synchronize];
 
     printf("[SETTINGS] SBC reset defaults dock=%ld hs=%ldx%ld hideLabels=%d rcReady=%d\n",
@@ -5820,7 +5893,9 @@ static BOOL settings_visual_refresh_enabled(NSUserDefaults *d)
            [d boolForKey:kSettingsBlurryBadgesEnabled] ||
            [d boolForKey:kSettingsAlkalineEnabled] ||
            [d boolForKey:kSettingsRoundedIconsEnabled] ||
-           [d boolForKey:kSettingsWatchLayoutEnabled];
+           [d boolForKey:kSettingsWatchLayoutEnabled] ||
+           [d boolForKey:kSettingsLockCustomizerEnabled] ||
+           [d boolForKey:kSettingsFreePlacementEnabled];
 }
 
 static void settings_visual_refresh_mark_if_ready(NSString *key, bool ready)
@@ -5860,6 +5935,10 @@ static void settings_visual_refresh_tick(NSUserDefaults *d, BOOL fullScan)
         settings_visual_refresh_mark_if_ready(kSettingsRoundedIconsEnabled, roundedicons_apply_in_session());
     if (fullScan && [d boolForKey:kSettingsWatchLayoutEnabled])
         settings_visual_refresh_mark_if_ready(kSettingsWatchLayoutEnabled, watchlayout_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsLockCustomizerEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsLockCustomizerEnabled, lockcustomizer_apply_in_session());
+    if (fullScan && [d boolForKey:kSettingsFreePlacementEnabled])
+        settings_visual_refresh_mark_if_ready(kSettingsFreePlacementEnabled, freeplacement_apply_in_session());
 }
 
 static void settings_start_visual_refresh_live_loop(void)
@@ -6255,7 +6334,12 @@ static BOOL settings_key_is_sbc(NSString *key)
            [key isEqualToString:kSettingsSBCDockIcons] ||
            [key isEqualToString:kSettingsSBCCols] ||
            [key isEqualToString:kSettingsSBCRows] ||
-           [key isEqualToString:kSettingsSBCHideLabels];
+           [key isEqualToString:kSettingsSBCHideLabels] ||
+           [key isEqualToString:kSettingsSBCHideBadges] ||
+           [key isEqualToString:kSettingsSBCHidePageDots] ||
+           [key isEqualToString:kSettingsSBCHideFolderBackground] ||
+           [key isEqualToString:kSettingsSBCHideDockBackground] ||
+           [key isEqualToString:kSettingsSBCIconAlphaPct];
 }
 
 static BOOL settings_key_is_sbc_configuration(NSString *key)
@@ -6263,7 +6347,12 @@ static BOOL settings_key_is_sbc_configuration(NSString *key)
     return [key isEqualToString:kSettingsSBCDockIcons] ||
            [key isEqualToString:kSettingsSBCCols] ||
            [key isEqualToString:kSettingsSBCRows] ||
-           [key isEqualToString:kSettingsSBCHideLabels];
+           [key isEqualToString:kSettingsSBCHideLabels] ||
+           [key isEqualToString:kSettingsSBCHideBadges] ||
+           [key isEqualToString:kSettingsSBCHidePageDots] ||
+           [key isEqualToString:kSettingsSBCHideFolderBackground] ||
+           [key isEqualToString:kSettingsSBCHideDockBackground] ||
+           [key isEqualToString:kSettingsSBCIconAlphaPct];
 }
 
 static void settings_note_package_configuration_changed(NSString *key)
@@ -6483,7 +6572,9 @@ static void settings_configure_control_center_tweaks(NSUserDefaults *d)
     blurrybadges_configure((int)[d integerForKey:kSettingsBlurryBadgesRed],
                            (int)[d integerForKey:kSettingsBlurryBadgesGreen],
                            (int)[d integerForKey:kSettingsBlurryBadgesBlue],
-                           (int)[d integerForKey:kSettingsBlurryBadgesAlphaPct]);
+                           (int)[d integerForKey:kSettingsBlurryBadgesAlphaPct],
+                           [d boolForKey:kSettingsBlurryBadgesGrowEnabled],
+                           (int)[d integerForKey:kSettingsBlurryBadgesMaxScalePct]);
     snapper_configure((int)[d integerForKey:kSettingsSnapperX],
                       (int)[d integerForKey:kSettingsSnapperY],
                       (int)[d integerForKey:kSettingsSnapperWidth],
@@ -6502,6 +6593,18 @@ static void settings_configure_control_center_tweaks(NSUserDefaults *d)
     roundedicons_configure((int)[d integerForKey:kSettingsRoundedIconsRadius]);
     watchlayout_configure((int)[d integerForKey:kSettingsWatchLayoutCompactPct],
                           (int)[d integerForKey:kSettingsWatchLayoutScalePct]);
+    NSInteger lockScale = [d objectForKey:kSettingsLockCustomizerClockScalePct] ? [d integerForKey:kSettingsLockCustomizerClockScalePct] : 100;
+    NSInteger lockAlpha = [d objectForKey:kSettingsLockCustomizerContentAlphaPct] ? [d integerForKey:kSettingsLockCustomizerContentAlphaPct] : 100;
+    lockcustomizer_configure((int)lockScale,
+                             (int)[d integerForKey:kSettingsLockCustomizerXOffset],
+                             (int)[d integerForKey:kSettingsLockCustomizerYOffset],
+                             [d boolForKey:kSettingsLockCustomizerHideQuickActions],
+                             [d boolForKey:kSettingsLockCustomizerHidePageDots],
+                             (int)lockAlpha);
+    NSInteger freeX = [d objectForKey:kSettingsFreePlacementHorizontalStep] ? [d integerForKey:kSettingsFreePlacementHorizontalStep] : 8;
+    NSInteger freeY = [d objectForKey:kSettingsFreePlacementVerticalStep] ? [d integerForKey:kSettingsFreePlacementVerticalStep] : 5;
+    NSInteger freeStagger = [d objectForKey:kSettingsFreePlacementStaggerPct] ? [d integerForKey:kSettingsFreePlacementStaggerPct] : 35;
+    freeplacement_configure((int)freeX, (int)freeY, (int)freeStagger);
 }
 
 static void settings_log_split_tweak_config(NSString *masterKey, NSUserDefaults *d, const char *prefix)
@@ -6557,11 +6660,13 @@ static void settings_log_split_tweak_config(NSString *masterKey, NSUserDefaults 
                  (long)[d integerForKey:kSettingsBarmojiFontSize],
                  (long)[d integerForKey:kSettingsBarmojiBackgroundAlphaPct]);
     } else if ([masterKey isEqualToString:kSettingsBlurryBadgesEnabled]) {
-        log_user("[%s] BlurryBadges config: rgba=%ld/%ld/%ld/%ld%%.\n", tag,
+        log_user("[%s] Badge Studio config: rgba=%ld/%ld/%ld/%ld%% grow=%d maxScale=%ld%%.\n", tag,
                  (long)[d integerForKey:kSettingsBlurryBadgesRed],
                  (long)[d integerForKey:kSettingsBlurryBadgesGreen],
                  (long)[d integerForKey:kSettingsBlurryBadgesBlue],
-                 (long)[d integerForKey:kSettingsBlurryBadgesAlphaPct]);
+                 (long)[d integerForKey:kSettingsBlurryBadgesAlphaPct],
+                 [d boolForKey:kSettingsBlurryBadgesGrowEnabled],
+                 (long)[d integerForKey:kSettingsBlurryBadgesMaxScalePct]);
     } else if ([masterKey isEqualToString:kSettingsSnapperEnabled]) {
         log_user("[%s] Snapper config: frame=%ld,%ld %ldx%ld border=%ld radius=%ld.\n", tag,
                  (long)[d integerForKey:kSettingsSnapperX],
@@ -6590,6 +6695,19 @@ static void settings_log_split_tweak_config(NSString *masterKey, NSUserDefaults 
         log_user("[%s] Watch Layout config: compact=%ld%% scale=%ld%% circular=1 pages=all discovered.\n", tag,
                  (long)[d integerForKey:kSettingsWatchLayoutCompactPct],
                  (long)[d integerForKey:kSettingsWatchLayoutScalePct]);
+    } else if ([masterKey isEqualToString:kSettingsLockCustomizerEnabled]) {
+        log_user("[%s] Lock Customizer config: clockScale=%ld%% x=%ld y=%ld quickActionsHidden=%d pageDotsHidden=%d alpha=%ld%%.\n", tag,
+                 (long)[d integerForKey:kSettingsLockCustomizerClockScalePct],
+                 (long)[d integerForKey:kSettingsLockCustomizerXOffset],
+                 (long)[d integerForKey:kSettingsLockCustomizerYOffset],
+                 [d boolForKey:kSettingsLockCustomizerHideQuickActions],
+                 [d boolForKey:kSettingsLockCustomizerHidePageDots],
+                 (long)[d integerForKey:kSettingsLockCustomizerContentAlphaPct]);
+    } else if ([masterKey isEqualToString:kSettingsFreePlacementEnabled]) {
+        log_user("[%s] Free Placement Lite config: horizontalStep=%ld verticalStep=%ld stagger=%ld%%; live icon taps preserved.\n", tag,
+                 (long)[d integerForKey:kSettingsFreePlacementHorizontalStep],
+                 (long)[d integerForKey:kSettingsFreePlacementVerticalStep],
+                 (long)[d integerForKey:kSettingsFreePlacementStaggerPct]);
     }
 }
 
@@ -6636,7 +6754,9 @@ static NSString *settings_split_tweak_master_key_for_key(NSString *key)
         [key isEqualToString:kSettingsBlurryBadgesRed] ||
         [key isEqualToString:kSettingsBlurryBadgesGreen] ||
         [key isEqualToString:kSettingsBlurryBadgesBlue] ||
-        [key isEqualToString:kSettingsBlurryBadgesAlphaPct]) return kSettingsBlurryBadgesEnabled;
+        [key isEqualToString:kSettingsBlurryBadgesAlphaPct] ||
+        [key isEqualToString:kSettingsBlurryBadgesGrowEnabled] ||
+        [key isEqualToString:kSettingsBlurryBadgesMaxScalePct]) return kSettingsBlurryBadgesEnabled;
     if ([key isEqualToString:kSettingsSnapperEnabled] ||
         [key isEqualToString:kSettingsSnapperX] ||
         [key isEqualToString:kSettingsSnapperY] ||
@@ -6660,6 +6780,17 @@ static NSString *settings_split_tweak_master_key_for_key(NSString *key)
     if ([key isEqualToString:kSettingsWatchLayoutEnabled] ||
         [key isEqualToString:kSettingsWatchLayoutCompactPct] ||
         [key isEqualToString:kSettingsWatchLayoutScalePct]) return kSettingsWatchLayoutEnabled;
+    if ([key isEqualToString:kSettingsLockCustomizerEnabled] ||
+        [key isEqualToString:kSettingsLockCustomizerClockScalePct] ||
+        [key isEqualToString:kSettingsLockCustomizerXOffset] ||
+        [key isEqualToString:kSettingsLockCustomizerYOffset] ||
+        [key isEqualToString:kSettingsLockCustomizerHideQuickActions] ||
+        [key isEqualToString:kSettingsLockCustomizerHidePageDots] ||
+        [key isEqualToString:kSettingsLockCustomizerContentAlphaPct]) return kSettingsLockCustomizerEnabled;
+    if ([key isEqualToString:kSettingsFreePlacementEnabled] ||
+        [key isEqualToString:kSettingsFreePlacementHorizontalStep] ||
+        [key isEqualToString:kSettingsFreePlacementVerticalStep] ||
+        [key isEqualToString:kSettingsFreePlacementStaggerPct]) return kSettingsFreePlacementEnabled;
     return nil;
 }
 
@@ -7753,6 +7884,12 @@ static void settings_schedule_live_apply_for_key(NSString *key)
                     } else if ([masterKey isEqualToString:kSettingsWatchLayoutEnabled]) {
                         ok = [d boolForKey:kSettingsWatchLayoutEnabled] ? watchlayout_apply_in_session() : watchlayout_stop_in_session();
                         settings_mark_tweak_applied(kSettingsWatchLayoutEnabled, ok && [d boolForKey:kSettingsWatchLayoutEnabled]);
+                    } else if ([masterKey isEqualToString:kSettingsLockCustomizerEnabled]) {
+                        ok = [d boolForKey:kSettingsLockCustomizerEnabled] ? lockcustomizer_apply_in_session() : lockcustomizer_stop_in_session();
+                        settings_mark_tweak_applied(kSettingsLockCustomizerEnabled, ok && [d boolForKey:kSettingsLockCustomizerEnabled]);
+                    } else if ([masterKey isEqualToString:kSettingsFreePlacementEnabled]) {
+                        ok = [d boolForKey:kSettingsFreePlacementEnabled] ? freeplacement_apply_in_session() : freeplacement_stop_in_session();
+                        settings_mark_tweak_applied(kSettingsFreePlacementEnabled, ok && [d boolForKey:kSettingsFreePlacementEnabled]);
                     }
                     printf("[SETTINGS] live split tweak %s owner=%s result=%d\n", key.UTF8String, masterKey.UTF8String, ok);
                 }
@@ -8218,6 +8355,11 @@ void settings_register_defaults(void)
         kSettingsSBCCols:       @(kSBCDefaultCols),
         kSettingsSBCRows:       @(kSBCDefaultRows),
         kSettingsSBCHideLabels: @(kSBCDefaultHideLabels),
+        kSettingsSBCHideBadges: @NO,
+        kSettingsSBCHidePageDots: @NO,
+        kSettingsSBCHideFolderBackground: @NO,
+        kSettingsSBCHideDockBackground: @NO,
+        kSettingsSBCIconAlphaPct: @100,
 
         kSettingsPowercuffEnabled: @NO,
         kSettingsPowercuffLevel:   @"nominal",
@@ -8239,6 +8381,8 @@ void settings_register_defaults(void)
         kSettingsLayoutDockExtraHorizontal: @0,
         kSettingsLayoutHomeScalePct:        @100,
         kSettingsLayoutDockScalePct:        @100,
+        kSettingsLayoutApplyHomeControls:   @YES,
+        kSettingsLayoutApplyDockControls:   @YES,
 
         kSettingsStatBarEnabled: @NO,
         kSettingsStatBarCelsius: @NO,
@@ -8363,11 +8507,24 @@ void settings_register_defaults(void)
         kSettingsWatchLayoutEnabled: @NO,
         kSettingsWatchLayoutCompactPct: @82,
         kSettingsWatchLayoutScalePct: @88,
+        kSettingsLockCustomizerEnabled: @NO,
+        kSettingsLockCustomizerClockScalePct: @100,
+        kSettingsLockCustomizerXOffset: @0,
+        kSettingsLockCustomizerYOffset: @0,
+        kSettingsLockCustomizerHideQuickActions: @NO,
+        kSettingsLockCustomizerHidePageDots: @NO,
+        kSettingsLockCustomizerContentAlphaPct: @100,
+        kSettingsFreePlacementEnabled: @NO,
+        kSettingsFreePlacementHorizontalStep: @8,
+        kSettingsFreePlacementVerticalStep: @5,
+        kSettingsFreePlacementStaggerPct: @35,
         kSettingsBlurryBadgesEnabled: @NO,
         kSettingsBlurryBadgesRed: @59,
         kSettingsBlurryBadgesGreen: @140,
         kSettingsBlurryBadgesBlue: @255,
         kSettingsBlurryBadgesAlphaPct: @92,
+        kSettingsBlurryBadgesGrowEnabled: @YES,
+        kSettingsBlurryBadgesMaxScalePct: @160,
         kSettingsSnapperEnabled: @NO,
         kSettingsSnapperX: @44,
         kSettingsSnapperY: @160,
@@ -8471,6 +8628,8 @@ void settings_register_defaults(void)
             kSettingsBarmojiEnabled,
             kSettingsRoundedIconsEnabled,
             kSettingsWatchLayoutEnabled,
+            kSettingsLockCustomizerEnabled,
+            kSettingsFreePlacementEnabled,
             kSettingsBlurryBadgesEnabled,
             kSettingsSnapperEnabled,
             kSettingsPullOverEnabled,
@@ -8543,7 +8702,9 @@ static void settings_log_tweak_plan_details(NSUserDefaults *d, BOOL pendingOnly)
         { kSettingsBarmojiEnabled, "Barmoji", "adds the configured emoji strip overlay to SpringBoard" },
         { kSettingsRoundedIconsEnabled, "Rounded Icons", "applies a continuous corner mask to every discovered Home Screen icon" },
         { kSettingsWatchLayoutEnabled, "Watch Layout", "compacts every discovered icon page into a circular Apple Watch-style grid" },
-        { kSettingsBlurryBadgesEnabled, "BlurryBadges", "tints visible notification badges with the configured color" },
+        { kSettingsLockCustomizerEnabled, "Lock Screen Customizer", "moves and scales the live clock and optionally hides quick actions and page dots" },
+        { kSettingsFreePlacementEnabled, "Free Placement Lite", "applies configurable free-form offsets to live icons while preserving taps" },
+        { kSettingsBlurryBadgesEnabled, "Badge Studio", "tints icon badges and scales them from their live notification counts" },
         { kSettingsSnapperEnabled, "Snapper", "shows the configured crop-frame overlay" },
         { kSettingsPullOverEnabled, "PullOver", "shows the configured slide-over tray shell" },
         { kSettingsAlkalineEnabled, "Alkaline", "tints visible battery views with the configured color" },
@@ -8662,6 +8823,8 @@ static void settings_run_actions_internal(BOOL pendingOnly)
             BOOL runBarmoji = settings_barmoji_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsBarmojiEnabled, springBoardPendingOnly);
             BOOL runRoundedIcons = settings_enabled_tweak_should_run(d, kSettingsRoundedIconsEnabled, springBoardPendingOnly);
             BOOL runWatchLayout = settings_enabled_tweak_should_run(d, kSettingsWatchLayoutEnabled, springBoardPendingOnly);
+            BOOL runLockCustomizer = cyanide_experimental_tweaks_available() && settings_enabled_tweak_should_run(d, kSettingsLockCustomizerEnabled, springBoardPendingOnly);
+            BOOL runFreePlacement = cyanide_experimental_tweaks_available() && settings_enabled_tweak_should_run(d, kSettingsFreePlacementEnabled, springBoardPendingOnly);
             BOOL runBlurryBadges = settings_blurrybadges_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsBlurryBadgesEnabled, springBoardPendingOnly);
             BOOL runSnapper = settings_snapper_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsSnapperEnabled, springBoardPendingOnly);
             BOOL runPullOver = settings_pullover_install_allowed() && settings_enabled_tweak_should_run(d, kSettingsPullOverEnabled, springBoardPendingOnly);
@@ -8682,7 +8845,7 @@ static void settings_run_actions_internal(BOOL pendingOnly)
                 settings_note_themer_stage_conflict(YES);
             }
             BOOL cleanupDisabledSpringBoardTweaks = settings_disabled_applied_springboard_cleanup_needed(d);
-            BOOL needsSpringBoardWork = runSBC || runDarkTweaks || runStatBar || runNSBar || runNiceBarLite || runRSSI || runAxonLite || runGravityLite || runLayoutExtras || runTypeBanner || runNotificationIsland || runVelvet || runCleanNC || runUnderTime || runZeppelinLite || runCleanHomeScreen || runRealCC || runCleanCC || runFUGap || runModuleSpacing || runSugarCane || runBetterCCXI || runMagma || runBetterCCIcons || runCCNoPlatterDim || runCCStatus || runHapticCC || runSecureCC || runHideLabels || runFakeClockUp || runPancake || runCylinderLite || runBarmoji || runRoundedIcons || runWatchLayout || runBlurryBadges || runSnapper || runPullOver || runAlkaline || runTweakLoader || runAppSwitcherGrid || runThemer || runSnowBoardLite || runLiveWP || runStageStrip || runFastLockXLite || runQuickLoader || runRepoTweaks || cleanupDisabledSpringBoardTweaks;
+            BOOL needsSpringBoardWork = runSBC || runDarkTweaks || runStatBar || runNSBar || runNiceBarLite || runRSSI || runAxonLite || runGravityLite || runLayoutExtras || runTypeBanner || runNotificationIsland || runVelvet || runCleanNC || runUnderTime || runZeppelinLite || runCleanHomeScreen || runRealCC || runCleanCC || runFUGap || runModuleSpacing || runSugarCane || runBetterCCXI || runMagma || runBetterCCIcons || runCCNoPlatterDim || runCCStatus || runHapticCC || runSecureCC || runHideLabels || runFakeClockUp || runPancake || runCylinderLite || runBarmoji || runRoundedIcons || runWatchLayout || runLockCustomizer || runFreePlacement || runBlurryBadges || runSnapper || runPullOver || runAlkaline || runTweakLoader || runAppSwitcherGrid || runThemer || runSnowBoardLite || runLiveWP || runStageStrip || runFastLockXLite || runQuickLoader || runRepoTweaks || cleanupDisabledSpringBoardTweaks;
             BOOL runSandboxEscape = [d boolForKey:kSettingsRunSandboxEscape] && (!pendingOnly || needsSpringBoardWork);
             // TypeBanner prewarms its hidden SpringBoard window during Apply
             // and reuses the open SpringBoard session for text-only updates.
@@ -8738,6 +8901,8 @@ static void settings_run_actions_internal(BOOL pendingOnly)
             if (runBarmoji) total++;
             if (runRoundedIcons) total++;
             if (runWatchLayout) total++;
+            if (runLockCustomizer) total++;
+            if (runFreePlacement) total++;
             if (runBlurryBadges) total++;
             if (runSnapper) total++;
             if (runPullOver) total++;
@@ -8786,6 +8951,8 @@ static void settings_run_actions_internal(BOOL pendingOnly)
             if (runBarmoji) [enabledTweaks addObject:@"barmoji"];
             if (runRoundedIcons) [enabledTweaks addObject:@"rounded-icons"];
             if (runWatchLayout) [enabledTweaks addObject:@"watch-layout"];
+            if (runLockCustomizer) [enabledTweaks addObject:@"lock-customizer"];
+            if (runFreePlacement) [enabledTweaks addObject:@"free-placement-lite"];
             if (runBlurryBadges) [enabledTweaks addObject:@"blurrybadges"];
             if (runSnapper) [enabledTweaks addObject:@"snapper"];
             if (runPullOver) [enabledTweaks addObject:@"pullover"];
@@ -9387,13 +9554,29 @@ static void settings_run_actions_internal(BOOL pendingOnly)
                         log_user("%s Watch Layout %s.\n", ok ? "[OK]" : "[WARN]", ok ? "active with tappable circular icons" : "found no icon views");
                     }
 
+                    if (runLockCustomizer) {
+                        settings_progress(&step, total, "Applying Lock Screen Customizer");
+                        settings_log_split_tweak_config(kSettingsLockCustomizerEnabled, d, "RUN");
+                        bool ok = lockcustomizer_apply_in_session();
+                        settings_mark_tweak_applied(kSettingsLockCustomizerEnabled, ok && [d boolForKey:kSettingsLockCustomizerEnabled]);
+                        log_user("%s Lock Screen Customizer %s.\n", ok ? "[OK]" : "[WARN]", ok ? "updated live clock and controls" : "found no matching lock-screen views yet");
+                    }
+
+                    if (runFreePlacement) {
+                        settings_progress(&step, total, "Applying Free Placement Lite");
+                        settings_log_split_tweak_config(kSettingsFreePlacementEnabled, d, "RUN");
+                        bool ok = freeplacement_apply_in_session();
+                        settings_mark_tweak_applied(kSettingsFreePlacementEnabled, ok && [d boolForKey:kSettingsFreePlacementEnabled]);
+                        log_user("%s Free Placement Lite %s.\n", ok ? "[OK]" : "[WARN]", ok ? "moved discovered live icons and preserved taps" : "found no icon views");
+                    }
+
                     if (runBlurryBadges) {
-                        settings_progress(&step, total, "Applying BlurryBadges");
+                        settings_progress(&step, total, "Applying Badge Studio");
                         settings_log_split_tweak_config(kSettingsBlurryBadgesEnabled, d, "RUN");
                         bool ok = blurrybadges_apply_in_session();
                         settings_mark_tweak_applied(kSettingsBlurryBadgesEnabled, ok && [d boolForKey:kSettingsBlurryBadgesEnabled]);
-                        printf("[SETTINGS] BlurryBadges result=%d\n", ok);
-                        log_user("%s BlurryBadges %s.\n", ok ? "[OK]" : "[WARN]", ok ? "active" : "did not find badge views yet");
+                        printf("[SETTINGS] Badge Studio result=%d\n", ok);
+                        log_user("%s Badge Studio %s.\n", ok ? "[OK]" : "[WARN]", ok ? "tint and count growth active" : "did not find icon badge views yet");
                         cyanide_upload_log_milestone(ok ? @"blurrybadges-applied" : @"blurrybadges-failed");
                     }
 
@@ -9703,6 +9886,8 @@ typedef NS_ENUM(NSInteger, SettingsSection) {
     SectionHideHomeBar,
     SectionRoundedIcons,
     SectionWatchLayout,
+    SectionLockCustomizer,
+    SectionFreePlacement,
     SectionCount,
 };
 
@@ -10475,6 +10660,13 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         @{ @"kind": @"stepper", @"key": kSettingsSBCCols,       @"title": @"Home columns", @"min": @3, @"max": @7, @"default": @(kSBCDefaultCols) },
         @{ @"kind": @"stepper", @"key": kSettingsSBCRows,       @"title": @"Home rows", @"min": @4, @"max": @8, @"default": @(kSBCDefaultRows) },
         @{ @"kind": @"toggle",  @"key": kSettingsSBCHideLabels, @"title": @"Hide icon labels" },
+        @{ @"kind": @"toggle",  @"key": kSettingsSBCHideBadges, @"title": @"Hide icon badges" },
+        @{ @"kind": @"toggle",  @"key": kSettingsSBCHidePageDots, @"title": @"Hide page dots" },
+        @{ @"kind": @"toggle",  @"key": kSettingsSBCHideFolderBackground, @"title": @"Hide folder backgrounds" },
+        @{ @"kind": @"toggle",  @"key": kSettingsSBCHideDockBackground, @"title": @"Hide dock background" },
+        @{ @"kind": @"slider", @"key": kSettingsSBCIconAlphaPct, @"title": @"Icon opacity", @"min": @20, @"max": @100, @"step": @1, @"default": @100, @"unit": @"%" },
+        @{ @"kind": @"info", @"title": @"Atria Lite controls", @"subtitle": @"These appearance controls are part of SBCustomizer and scan every discovered Home Screen window." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
         @{ @"kind": @"button",  @"title": @"Reset to Defaults" },
     ];
 }
@@ -10551,6 +10743,8 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
 - (NSArray<NSDictionary *> *)darkSwordTweakRows
 {
     return @[
+        @{ @"kind": @"toggle", @"key": kSettingsLayoutApplyHomeControls, @"title": @"Apply Home Screen controls" },
+        @{ @"kind": @"toggle", @"key": kSettingsLayoutApplyDockControls, @"title": @"Apply Dock controls" },
         @{ @"kind": @"info", @"title": @"Runtime behavior",
            @"subtitle": @"The installed DarkSword patch changes SpringBoard in memory. A respring restores stock behavior." },
         @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
@@ -10586,6 +10780,8 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
            @"title": @"Home icon scale",   @"min": @25, @"max": @250, @"step": @1, @"unit": @"%", @"default": @100 },
         @{ @"kind": @"number", @"key": kSettingsLayoutDockScalePct,
            @"title": @"Dock icon scale",   @"min": @25, @"max": @250, @"step": @1, @"unit": @"%", @"default": @100 },
+        @{ @"kind": @"info", @"title": @"Atria Lite groups", @"subtitle": @"Home and Dock controls can now be toggled independently without losing the configured values." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
     ];
 }
 
@@ -10920,6 +11116,33 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
     ];
 }
 
+- (NSArray<NSDictionary *> *)lockCustomizerRows
+{
+    return @[
+        @{ @"kind": @"toggle", @"key": kSettingsLockCustomizerEnabled, @"title": @"Enable Lock Screen Customizer" },
+        @{ @"kind": @"slider", @"key": kSettingsLockCustomizerClockScalePct, @"title": @"Clock size", @"min": @50, @"max": @180, @"step": @1, @"default": @100, @"unit": @"%" },
+        @{ @"kind": @"slider", @"key": kSettingsLockCustomizerXOffset, @"title": @"Clock horizontal offset", @"min": @-160, @"max": @160, @"step": @1, @"default": @0, @"unit": @"pt" },
+        @{ @"kind": @"slider", @"key": kSettingsLockCustomizerYOffset, @"title": @"Clock vertical offset", @"min": @-300, @"max": @300, @"step": @1, @"default": @0, @"unit": @"pt" },
+        @{ @"kind": @"slider", @"key": kSettingsLockCustomizerContentAlphaPct, @"title": @"Clock opacity", @"min": @20, @"max": @100, @"step": @1, @"default": @100, @"unit": @"%" },
+        @{ @"kind": @"toggle", @"key": kSettingsLockCustomizerHideQuickActions, @"title": @"Hide camera and flashlight" },
+        @{ @"kind": @"toggle", @"key": kSettingsLockCustomizerHidePageDots, @"title": @"Hide lock-screen page dots" },
+        @{ @"kind": @"info", @"title": @"Safe restore", @"subtitle": @"Uninstall restores stock transforms and visibility for all matched live lock-screen views." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
+}
+
+- (NSArray<NSDictionary *> *)freePlacementRows
+{
+    return @[
+        @{ @"kind": @"toggle", @"key": kSettingsFreePlacementEnabled, @"title": @"Enable Free Placement Lite" },
+        @{ @"kind": @"slider", @"key": kSettingsFreePlacementHorizontalStep, @"title": @"Horizontal offset step", @"min": @-40, @"max": @40, @"step": @1, @"default": @8, @"unit": @"pt" },
+        @{ @"kind": @"slider", @"key": kSettingsFreePlacementVerticalStep, @"title": @"Vertical offset step", @"min": @-40, @"max": @40, @"step": @1, @"default": @5, @"unit": @"pt" },
+        @{ @"kind": @"slider", @"key": kSettingsFreePlacementStaggerPct, @"title": @"Alternate-icon stagger", @"min": @0, @"max": @100, @"step": @1, @"default": @35, @"unit": @"%" },
+        @{ @"kind": @"info", @"title": @"First port", @"subtitle": @"Builds a configurable free-form offset pattern across all discovered live icons. Taps work; per-icon dragging is not included yet." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
+    ];
+}
+
 - (NSArray<NSDictionary *> *)blurrybadgesRows
 {
     return @[
@@ -10928,6 +11151,10 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         @{ @"kind": @"slider", @"key": kSettingsBlurryBadgesGreen, @"title": @"Green", @"min": @0, @"max": @255, @"step": @1, @"default": @140 },
         @{ @"kind": @"slider", @"key": kSettingsBlurryBadgesBlue, @"title": @"Blue", @"min": @0, @"max": @255, @"step": @1, @"default": @255 },
         @{ @"kind": @"slider", @"key": kSettingsBlurryBadgesAlphaPct, @"title": @"Tint alpha", @"min": @10, @"max": @100, @"step": @1, @"default": @92, @"unit": @"%" },
+        @{ @"kind": @"toggle", @"key": kSettingsBlurryBadgesGrowEnabled, @"title": @"Grow badges with notification count" },
+        @{ @"kind": @"slider", @"key": kSettingsBlurryBadgesMaxScalePct, @"title": @"Maximum badge size", @"min": @100, @"max": @220, @"step": @1, @"default": @160, @"unit": @"%" },
+        @{ @"kind": @"info", @"title": @"Growing Badges+", @"subtitle": @"Reads each live badge value and scales larger counts toward the configured maximum. All discovered SpringBoard windows are scanned." },
+        @{ @"kind": @"button", @"title": @"View Detailed Activity Log", @"action": @"view-log" },
     ];
 }
 
@@ -11594,6 +11821,8 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
         case SectionHideHomeBar: return self.hideHomeBarRows;
         case SectionRoundedIcons: return self.roundedIconsRows;
         case SectionWatchLayout: return self.watchLayoutRows;
+        case SectionLockCustomizer: return cyanide_experimental_tweaks_available() ? self.lockCustomizerRows : @[];
+        case SectionFreePlacement: return cyanide_experimental_tweaks_available() ? self.freePlacementRows : @[];
         default: return @[];
     }
 }
@@ -11665,6 +11894,8 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
 #endif
         @{ @"title": @"Rounded Icons", @"icon": @"app.fill", @"color": [UIColor systemBlueColor], @"section": @(SectionRoundedIcons) },
         @{ @"title": @"Watch Layout", @"icon": @"circle.grid.3x3.fill", @"color": [UIColor systemGreenColor], @"section": @(SectionWatchLayout) },
+        @{ @"title": @"Lock Screen Customizer", @"icon": @"lock.rectangle", @"color": [UIColor systemIndigoColor], @"section": @(SectionLockCustomizer), @"experimental": @YES },
+        @{ @"title": @"Free Placement Lite", @"icon": @"move.3d", @"color": [UIColor systemPinkColor], @"section": @(SectionFreePlacement), @"experimental": @YES },
     ];
 }
 
@@ -11918,8 +12149,14 @@ static _CyanideMailDelegate *_cyanide_mail_delegate(void) {
     if (s == SectionWatchLayout) {
         return @"Compacts every discovered Home Screen page into a circular Apple Watch-style layout. Refreshes use saved stock frames, so the layout does not keep shrinking and can be restored.";
     }
+    if (s == SectionLockCustomizer) {
+        return @"Resizes and repositions the live Lock Screen clock and optionally hides quick actions or page dots. Changes are session-based, logged, and restored on uninstall.";
+    }
+    if (s == SectionFreePlacement) {
+        return @"Applies a configurable staggered offset pattern to every discovered live Home Screen icon. Icons remain pressable and saved stock frames are restored on uninstall; per-icon dragging is not included yet.";
+    }
     if (s == SectionBlurryBadges) {
-        return @"Tints visible notification badge views for a softer, colorized badge look.";
+        return @"Badge Studio combines configurable BlurryBadges tinting with Growing Badges+ scaling based on each live notification count.";
     }
     if (s == SectionSnapper) {
         return @"Shows a first-pass crop frame overlay for Snapper-style pinned screenshots.";

--- a/Infern0/installer/PackageCatalog.m
+++ b/Infern0/installer/PackageCatalog.m
@@ -160,6 +160,8 @@ static const NSInteger kSecCallRecordingSound = 55;
 static const NSInteger kSecHideHomeBar      = 56;
 static const NSInteger kSecRoundedIcons     = 57;
 static const NSInteger kSecWatchLayout      = 58;
+static const NSInteger kSecLockCustomizer   = 59;
+static const NSInteger kSecFreePlacement    = 60;
 static const NSInteger kSecDarkSwordTweaks  = 13;
 
 + (NSArray<Package *> *)allPackages
@@ -790,10 +792,36 @@ static const NSInteger kSecDarkSwordTweaks  = 13;
                                           isNew:YES];
         watchLayout.settingsSection = kSecWatchLayout;
 
+        Package *lockCustomizer = [[Package alloc] initWithIdentifier:@"com.darksword.lockcustomizer"
+                                           name:@"Lock Screen Customizer"
+                               shortDescription:@"Move, resize, and clean up the Lock Screen"
+                                longDescription:@"A configurable Lock Screen customizer that resizes and repositions the live clock, adjusts its opacity, and can hide camera, flashlight, and page-dot views. Every matched change is logged and uninstall restores stock transforms and visibility."
+                                        version:version
+                                         author:@"Nnnnnnn274"
+                                       category:@"Lock Screen"
+                                     symbolName:@"lock.rectangle"
+                                           kind:PackageInstallKindToggle
+                                     enabledKey:kSettingsLockCustomizerEnabled
+                                          isNew:YES];
+        lockCustomizer.settingsSection = kSecLockCustomizer;
+
+        Package *freePlacement = [[Package alloc] initWithIdentifier:@"com.darksword.freeplacementlite"
+                                           name:@"Free Placement Lite"
+                               shortDescription:@"Configurable free-form icon offsets"
+                                longDescription:@"Creates a configurable staggered, free-form layout across every discovered live Home Screen icon while keeping icons pressable. This first RemoteCall port provides global placement controls and clean frame restoration; per-icon dragging is not included yet."
+                                        version:version
+                                         author:@"Nnnnnnn274"
+                                       category:@"Home Screen"
+                                     symbolName:@"move.3d"
+                                           kind:PackageInstallKindToggle
+                                     enabledKey:kSettingsFreePlacementEnabled
+                                          isNew:YES];
+        freePlacement.settingsSection = kSecFreePlacement;
+
         Package *blurryBadges = [[Package alloc] initWithIdentifier:@"com.darksword.blurrybadges"
-                                           name:@"BlurryBadges"
-                               shortDescription:@"Colorized notification badges"
-                                longDescription:@"First-pass BlurryBadges port. Tints visible SpringBoard badge views for a softer colorized look.\n\nDominant app-icon color extraction is planned; this version applies a stable badge tint pass."
+                                           name:@"Badge Studio"
+                               shortDescription:@"Colorized badges that grow with the count"
+                                longDescription:@"Combines the BlurryBadges tint pass with Growing Badges+ behavior. It scans every discovered SpringBoard window, reads live badge values, and scales larger counts toward a configurable maximum. Tint, opacity, growth, and maximum size all have settings and detailed logs."
                                         version:version
                                          author:@"Nnnnnnn274"
                                        category:@"Home Screen"
@@ -1042,6 +1070,8 @@ static const NSInteger kSecDarkSwordTweaks  = 13;
             barmoji,
             roundedIcons,
             watchLayout,
+            lockCustomizer,
+            freePlacement,
             blurryBadges,
             snapper,
             pullOver,

--- a/Infern0/tweaks/experimental/blurrybadges.h
+++ b/Infern0/tweaks/experimental/blurrybadges.h
@@ -5,7 +5,8 @@
 
 bool blurrybadges_apply_in_session(void);
 bool blurrybadges_stop_in_session(void);
-void blurrybadges_configure(int red, int green, int blue, int alphaPercent);
+void blurrybadges_configure(int red, int green, int blue, int alphaPercent,
+                            bool growEnabled, int maxScalePercent);
 void blurrybadges_forget_remote_state(void);
 
 #endif

--- a/Infern0/tweaks/experimental/blurrybadges.m
+++ b/Infern0/tweaks/experimental/blurrybadges.m
@@ -11,6 +11,9 @@ static int gBlurryBadgesRed = 59;
 static int gBlurryBadgesGreen = 140;
 static int gBlurryBadgesBlue = 255;
 static int gBlurryBadgesAlphaPercent = 92;
+static bool gBlurryBadgesGrowEnabled = true;
+static int gBlurryBadgesMaxScalePercent = 160;
+typedef struct { double a, b, c, d, tx, ty; } BlurryBadgesAffine;
 
 static uint64_t blurrybadges_color(double red, double green, double blue, double alpha)
 {
@@ -60,16 +63,40 @@ static void blurrybadges_class_name(uint64_t obj, char *out, size_t outLen)
     r_free(buf);
 }
 
-static void blurrybadges_scan_and_tint(uint64_t parent, uint64_t color, int depth, int *hits)
+static int blurrybadges_count(uint64_t badge)
+{
+    const char *selectors[] = { "badgeValue", "text", "string" };
+    for (int i = 0; i < 3; i++) {
+        if (!r_responds_main(badge, selectors[i])) continue;
+        uint64_t value = r_msg2_main(badge, selectors[i], 0, 0, 0, 0);
+        if (r_is_objc_ptr(value) && r_responds_main(value, "integerValue")) {
+            int count = (int)r_msg2_main(value, "integerValue", 0, 0, 0, 0);
+            if (count > 0) return count;
+        }
+    }
+    return 1;
+}
+
+static void blurrybadges_scan_and_tint(uint64_t parent, uint64_t color, bool restore, int depth, int *hits, int *grown)
 {
     if (!r_is_objc_ptr(parent) || !r_is_objc_ptr(color) || depth > 12) return;
 
     char cls[128] = {0};
     blurrybadges_class_name(parent, cls, sizeof(cls));
-    if (strstr(cls, "Badge")) {
+    if (strstr(cls, "IconBadge") || strstr(cls, "SBIconBadge")) {
         r_msg2_main(parent, "setTintColor:", color, 0, 0, 0);
         if (r_responds_main(parent, "setTextColor:")) r_msg2_main(parent, "setTextColor:", color, 0, 0, 0);
         if (r_responds_main(parent, "setBackgroundColor:")) r_msg2_main(parent, "setBackgroundColor:", color, 0, 0, 0);
+        if (r_responds_main(parent, "setTransform:")) {
+            int count = restore ? 1 : blurrybadges_count(parent);
+            if (count > 99) count = 99;
+            double scale = (!restore && gBlurryBadgesGrowEnabled)
+                ? 1.0 + ((double)(count - 1) / 98.0) * ((double)(gBlurryBadgesMaxScalePercent - 100) / 100.0)
+                : 1.0;
+            BlurryBadgesAffine transform = { scale, 0, 0, scale, 0, 0 };
+            r_msg2_main_raw(parent, "setTransform:", &transform, sizeof(transform), NULL, 0, NULL, 0, NULL, 0);
+            if (scale > 1.001 && grown) (*grown)++;
+        }
         if (hits) (*hits)++;
     }
 
@@ -79,37 +106,39 @@ static void blurrybadges_scan_and_tint(uint64_t parent, uint64_t color, int dept
     if (count > 128) count = 128;
     for (uint64_t i = 0; i < count; i++) {
         uint64_t sv = r_msg2_main(subviews, "objectAtIndex:", i, 0, 0, 0);
-        blurrybadges_scan_and_tint(sv, color, depth + 1, hits);
+        blurrybadges_scan_and_tint(sv, color, restore, depth + 1, hits, grown);
     }
 }
 
 bool blurrybadges_apply_in_session(void)
 {
     printf("[BLURRYBADGES] apply\n");
-    uint64_t win = sb_frontmost_window();
-    if (!r_is_objc_ptr(win)) return false;
     gBlurryBadgesTint = blurrybadges_color((double)gBlurryBadgesRed / 255.0,
                                            (double)gBlurryBadgesGreen / 255.0,
                                            (double)gBlurryBadgesBlue / 255.0,
                                            (double)gBlurryBadgesAlphaPercent / 100.0);
-    int hits = 0;
-    blurrybadges_scan_and_tint(win, gBlurryBadgesTint, 0, &hits);
-    printf("[BLURRYBADGES] tinted %d badge-ish views\n", hits);
+    uint64_t windows[64] = {0};
+    int windowCount = sb_collect_windows(windows, 64), hits = 0, grown = 0;
+    for (int i = 0; i < windowCount; i++)
+        blurrybadges_scan_and_tint(windows[i], gBlurryBadgesTint, false, 0, &hits, &grown);
+    printf("[BLURRYBADGES] tinted=%d grown=%d maxScale=%d%% windows=%d\n", hits, grown, gBlurryBadgesMaxScalePercent, windowCount);
     return hits > 0;
 }
 
 bool blurrybadges_stop_in_session(void)
 {
     printf("[BLURRYBADGES] stop\n");
-    uint64_t win = sb_frontmost_window();
     uint64_t red = blurrybadges_color(1.0, 0.23, 0.19, 1.0);
-    int hits = 0;
-    if (r_is_objc_ptr(win)) blurrybadges_scan_and_tint(win, red, 0, &hits);
+    uint64_t windows[64] = {0};
+    int windowCount = sb_collect_windows(windows, 64), hits = 0, grown = 0;
+    for (int i = 0; i < windowCount; i++)
+        blurrybadges_scan_and_tint(windows[i], red, true, 0, &hits, &grown);
     gBlurryBadgesTint = 0;
     return true;
 }
 
-void blurrybadges_configure(int red, int green, int blue, int alphaPercent)
+void blurrybadges_configure(int red, int green, int blue, int alphaPercent,
+                            bool growEnabled, int maxScalePercent)
 {
     if (red < 0) red = 0; if (red > 255) red = 255;
     if (green < 0) green = 0; if (green > 255) green = 255;
@@ -119,6 +148,10 @@ void blurrybadges_configure(int red, int green, int blue, int alphaPercent)
     gBlurryBadgesGreen = green;
     gBlurryBadgesBlue = blue;
     gBlurryBadgesAlphaPercent = alphaPercent;
+    if (maxScalePercent < 100) maxScalePercent = 100;
+    if (maxScalePercent > 220) maxScalePercent = 220;
+    gBlurryBadgesGrowEnabled = growEnabled;
+    gBlurryBadgesMaxScalePercent = maxScalePercent;
 }
 
 void blurrybadges_forget_remote_state(void) { gBlurryBadgesTint = 0; }

--- a/Infern0/tweaks/experimental/customizers.h
+++ b/Infern0/tweaks/experimental/customizers.h
@@ -1,0 +1,43 @@
+#ifndef customizers_h
+#define customizers_h
+
+#include <stdbool.h>
+
+void homecustom_configure(bool hideBadges, bool hidePageDots, bool hideFolderBackground,
+                          bool hideDockBackground, int iconAlphaPercent);
+bool homecustom_apply_in_session(void);
+bool homecustom_stop_in_session(void);
+void homecustom_forget_remote_state(void);
+
+void freeplacement_configure(int horizontalStep, int verticalStep, int staggerPercent);
+bool freeplacement_apply_in_session(void);
+bool freeplacement_stop_in_session(void);
+void freeplacement_forget_remote_state(void);
+
+void lockcustomizer_configure(int clockScalePercent, int horizontalOffset, int verticalOffset,
+                              bool hideQuickActions, bool hidePageDots, int contentAlphaPercent);
+bool lockcustomizer_apply_in_session(void);
+bool lockcustomizer_stop_in_session(void);
+void lockcustomizer_forget_remote_state(void);
+
+#endif
+#pragma once
+
+#include <stdbool.h>
+
+void homecustom_configure(bool hideBadges, bool hidePageDots, bool hideFolderBackground,
+                          bool hideDockBackground, int iconAlphaPercent);
+bool homecustom_apply_in_session(void);
+bool homecustom_stop_in_session(void);
+void homecustom_forget_remote_state(void);
+
+void freeplacement_configure(int horizontalStep, int verticalStep, int staggerPercent);
+bool freeplacement_apply_in_session(void);
+bool freeplacement_stop_in_session(void);
+void freeplacement_forget_remote_state(void);
+
+void lockcustomizer_configure(int clockScalePercent, int horizontalOffset, int verticalOffset,
+                              bool hideQuickActions, bool hidePageDots, int contentAlphaPercent);
+bool lockcustomizer_apply_in_session(void);
+bool lockcustomizer_stop_in_session(void);
+void lockcustomizer_forget_remote_state(void);

--- a/Infern0/tweaks/experimental/customizers.m
+++ b/Infern0/tweaks/experimental/customizers.m
@@ -1,0 +1,282 @@
+#import "customizers.h"
+#import "../remote_objc.h"
+#import "../sb_walk.h"
+#import "../../TaskRop/RemoteCall.h"
+
+#import <Foundation/Foundation.h>
+#import <math.h>
+#import <string.h>
+
+typedef struct { double x, y, width, height; } CUSRect;
+typedef struct { double a, b, c, d, tx, ty; } CUSAffine;
+
+static bool gHomeHideBadges = false;
+static bool gHomeHideDots = false;
+static bool gHomeHideFolderBackground = false;
+static bool gHomeHideDockBackground = false;
+static int gHomeIconAlpha = 100;
+
+static int gFreeHorizontalStep = 8;
+static int gFreeVerticalStep = 5;
+static int gFreeStaggerPercent = 35;
+static uint64_t gFreeIcons[512] = {0};
+static CUSRect gFreeFrames[512] = {0};
+static int gFreeIconCount = 0;
+
+static int gLockClockScale = 100;
+static int gLockXOffset = 0;
+static int gLockYOffset = 0;
+static bool gLockHideQuickActions = false;
+static bool gLockHideDots = false;
+static int gLockContentAlpha = 100;
+
+static void cus_class_name(uint64_t obj, char *out, size_t outLen)
+{
+    if (!out || outLen == 0) return;
+    out[0] = '\0';
+    if (!r_is_objc_ptr(obj)) return;
+    uint64_t cls = r_dlsym_call(R_TIMEOUT, "object_getClass", obj, 0, 0, 0, 0, 0, 0, 0);
+    uint64_t name = r_is_objc_ptr(cls)
+        ? r_dlsym_call(R_TIMEOUT, "class_getName", cls, 0, 0, 0, 0, 0, 0, 0) : 0;
+    if (!name) return;
+    uint64_t copy = r_dlsym_call(R_TIMEOUT, "strdup", name, 0, 0, 0, 0, 0, 0, 0);
+    if (!copy) return;
+    remote_read(copy, out, outLen - 1);
+    out[outLen - 1] = '\0';
+    r_free(copy);
+}
+
+static void cus_set_alpha(uint64_t view, double alpha)
+{
+    if (r_is_objc_ptr(view) && r_responds_main(view, "setAlpha:"))
+        r_msg2_main_raw(view, "setAlpha:", &alpha, sizeof(alpha), NULL, 0, NULL, 0, NULL, 0);
+}
+
+static bool cus_get_rect(uint64_t view, const char *sel, CUSRect *out)
+{
+    if (!r_is_objc_ptr(view) || !out || !r_responds_main(view, sel)) return false;
+    memset(out, 0, sizeof(*out));
+    return r_msg2_main_struct_ret(view, sel, out, sizeof(*out), NULL, 0, NULL, 0, NULL, 0, NULL, 0);
+}
+
+static void cus_set_rect(uint64_t view, CUSRect frame)
+{
+    if (r_is_objc_ptr(view) && r_responds_main(view, "setFrame:"))
+        r_msg2_main_raw(view, "setFrame:", &frame, sizeof(frame), NULL, 0, NULL, 0, NULL, 0);
+}
+
+static void cus_set_transform(uint64_t view, CUSAffine transform)
+{
+    if (r_is_objc_ptr(view) && r_responds_main(view, "setTransform:"))
+        r_msg2_main_raw(view, "setTransform:", &transform, sizeof(transform), NULL, 0, NULL, 0, NULL, 0);
+}
+
+static bool cus_contains(const char *name, const char *needle)
+{
+    return name && needle && strstr(name, needle) != NULL;
+}
+
+static void homecustom_scan(uint64_t view, int depth, int *changed)
+{
+    if (!r_is_objc_ptr(view) || depth > 16) return;
+    char cls[160] = {0};
+    cus_class_name(view, cls, sizeof(cls));
+    bool touched = false;
+
+    if ((cus_contains(cls, "IconBadge") || cus_contains(cls, "SBIconBadge")) && !cus_contains(cls, "Label")) {
+        cus_set_alpha(view, gHomeHideBadges ? 0.0 : 1.0); touched = true;
+    } else if ((cus_contains(cls, "PageControl") || cus_contains(cls, "PageIndicator") || cus_contains(cls, "PageDot")) &&
+               (cus_contains(cls, "SBIcon") || cus_contains(cls, "HomeScreen") || cus_contains(cls, "RootFolder"))) {
+        cus_set_alpha(view, gHomeHideDots ? 0.0 : 1.0); touched = true;
+    } else if (cus_contains(cls, "FolderIconBackground") || cus_contains(cls, "FolderBackground")) {
+        cus_set_alpha(view, gHomeHideFolderBackground ? 0.0 : 1.0); touched = true;
+    } else if (cus_contains(cls, "DockBackground") || cus_contains(cls, "DockPlatter") ||
+               cus_contains(cls, "DockMaterial") || cus_contains(cls, "DockEffect")) {
+        cus_set_alpha(view, gHomeHideDockBackground ? 0.0 : 1.0); touched = true;
+    } else if (cus_contains(cls, "SBIconView")) {
+        cus_set_alpha(view, (double)gHomeIconAlpha / 100.0);
+        r_msg2_main(view, "setUserInteractionEnabled:", 1, 0, 0, 0);
+        touched = true;
+    }
+    if (touched && changed) (*changed)++;
+
+    uint64_t subs = r_msg2_main(view, "subviews", 0, 0, 0, 0);
+    uint64_t count = r_is_objc_ptr(subs) ? r_msg2_main(subs, "count", 0, 0, 0, 0) : 0;
+    if (count > 256) count = 256;
+    for (uint64_t i = 0; i < count; i++)
+        homecustom_scan(r_msg2_main(subs, "objectAtIndex:", i, 0, 0, 0), depth + 1, changed);
+}
+
+void homecustom_configure(bool hideBadges, bool hidePageDots, bool hideFolderBackground,
+                          bool hideDockBackground, int iconAlphaPercent)
+{
+    if (iconAlphaPercent < 20) iconAlphaPercent = 20;
+    if (iconAlphaPercent > 100) iconAlphaPercent = 100;
+    gHomeHideBadges = hideBadges;
+    gHomeHideDots = hidePageDots;
+    gHomeHideFolderBackground = hideFolderBackground;
+    gHomeHideDockBackground = hideDockBackground;
+    gHomeIconAlpha = iconAlphaPercent;
+}
+
+bool homecustom_apply_in_session(void)
+{
+    uint64_t windows[64] = {0};
+    int windowCount = sb_collect_windows(windows, 64), changed = 0;
+    for (int i = 0; i < windowCount; i++) homecustom_scan(windows[i], 0, &changed);
+    printf("[HOMECUSTOM] badges=%d dots=%d folders=%d dock=%d iconAlpha=%d changed=%d windows=%d\n",
+           gHomeHideBadges, gHomeHideDots, gHomeHideFolderBackground,
+           gHomeHideDockBackground, gHomeIconAlpha, changed, windowCount);
+    return changed > 0;
+}
+
+bool homecustom_stop_in_session(void)
+{
+    bool oldBadges = gHomeHideBadges, oldDots = gHomeHideDots;
+    bool oldFolders = gHomeHideFolderBackground, oldDock = gHomeHideDockBackground;
+    int oldAlpha = gHomeIconAlpha;
+    homecustom_configure(false, false, false, false, 100);
+    bool ok = homecustom_apply_in_session();
+    homecustom_configure(oldBadges, oldDots, oldFolders, oldDock, oldAlpha);
+    printf("[HOMECUSTOM] restored stock visibility\n");
+    return ok;
+}
+
+void homecustom_forget_remote_state(void) {}
+
+static int free_saved_index(uint64_t icon)
+{
+    for (int i = 0; i < gFreeIconCount; i++) if (gFreeIcons[i] == icon) return i;
+    return -1;
+}
+
+void freeplacement_configure(int horizontalStep, int verticalStep, int staggerPercent)
+{
+    if (horizontalStep < -40) horizontalStep = -40;
+    if (horizontalStep > 40) horizontalStep = 40;
+    if (verticalStep < -40) verticalStep = -40;
+    if (verticalStep > 40) verticalStep = 40;
+    if (staggerPercent < 0) staggerPercent = 0;
+    if (staggerPercent > 100) staggerPercent = 100;
+    gFreeHorizontalStep = horizontalStep;
+    gFreeVerticalStep = verticalStep;
+    gFreeStaggerPercent = staggerPercent;
+}
+
+bool freeplacement_apply_in_session(void)
+{
+    uint64_t cls = r_class("SBIconView"), icons[512] = {0};
+    int count = r_is_objc_ptr(cls) ? sb_collect_views_in_windows(cls, icons, 512) : 0;
+    int moved = 0;
+    for (int i = 0; i < count; i++) {
+        uint64_t icon = icons[i];
+        CUSRect frame;
+        if (!cus_get_rect(icon, "frame", &frame) || frame.width <= 0 || frame.height <= 0) continue;
+        int saved = free_saved_index(icon);
+        if (saved < 0 && gFreeIconCount < 512) {
+            saved = gFreeIconCount;
+            gFreeIcons[gFreeIconCount] = icon;
+            gFreeFrames[gFreeIconCount++] = frame;
+        }
+        if (saved >= 0) frame = gFreeFrames[saved];
+        int columnPhase = (i % 5) - 2;
+        int rowPhase = ((i / 5) % 5) - 2;
+        double stagger = (i & 1) ? (double)gFreeStaggerPercent / 100.0 : 0.0;
+        frame.x += (double)columnPhase * gFreeHorizontalStep + stagger * gFreeHorizontalStep;
+        frame.y += (double)rowPhase * gFreeVerticalStep;
+        cus_set_rect(icon, frame);
+        r_msg2_main(icon, "setUserInteractionEnabled:", 1, 0, 0, 0);
+        moved++;
+    }
+    printf("[FREEPLACEMENT] horizontalStep=%d verticalStep=%d stagger=%d%% moved=%d saved=%d taps=preserved\n",
+           gFreeHorizontalStep, gFreeVerticalStep, gFreeStaggerPercent, moved, gFreeIconCount);
+    return moved > 0;
+}
+
+bool freeplacement_stop_in_session(void)
+{
+    int restored = 0;
+    for (int i = 0; i < gFreeIconCount; i++) {
+        if (!r_is_objc_ptr(gFreeIcons[i])) continue;
+        cus_set_rect(gFreeIcons[i], gFreeFrames[i]);
+        restored++;
+    }
+    memset(gFreeIcons, 0, sizeof(gFreeIcons));
+    memset(gFreeFrames, 0, sizeof(gFreeFrames));
+    gFreeIconCount = 0;
+    printf("[FREEPLACEMENT] restored=%d\n", restored);
+    return true;
+}
+
+void freeplacement_forget_remote_state(void)
+{
+    memset(gFreeIcons, 0, sizeof(gFreeIcons));
+    memset(gFreeFrames, 0, sizeof(gFreeFrames));
+    gFreeIconCount = 0;
+}
+
+static void lockcustomizer_scan(uint64_t view, int depth, bool lockContext, bool restore, int *changed)
+{
+    if (!r_is_objc_ptr(view) || depth > 18) return;
+    char cls[160] = {0};
+    cus_class_name(view, cls, sizeof(cls));
+    bool isLock = cus_contains(cls, "LockScreen") || cus_contains(cls, "CoverSheet") ||
+                  cus_contains(cls, "CSPageControl") || cus_contains(cls, "CSCoverSheet") ||
+                  cus_contains(cls, "CSMainPage") || cus_contains(cls, "SBDashBoard");
+    lockContext = lockContext || isLock;
+    bool isClock = cus_contains(cls, "DateView") || cus_contains(cls, "ClockView") || cus_contains(cls, "TimeView");
+    bool isQuick = cus_contains(cls, "QuickAction") || cus_contains(cls, "CameraGrabber") || cus_contains(cls, "Flashlight");
+    bool isDots = cus_contains(cls, "PageControl") || cus_contains(cls, "PageIndicator");
+    if (isClock && lockContext) {
+        double scale = restore ? 1.0 : (double)gLockClockScale / 100.0;
+        CUSAffine t = {scale, 0, 0, scale, restore ? 0.0 : gLockXOffset, restore ? 0.0 : gLockYOffset};
+        cus_set_transform(view, t);
+        cus_set_alpha(view, restore ? 1.0 : (double)gLockContentAlpha / 100.0);
+        if (changed) (*changed)++;
+    } else if (isQuick && lockContext) {
+        cus_set_alpha(view, (!restore && gLockHideQuickActions) ? 0.0 : 1.0);
+        if (changed) (*changed)++;
+    } else if (isDots && lockContext) {
+        cus_set_alpha(view, (!restore && gLockHideDots) ? 0.0 : 1.0);
+        if (changed) (*changed)++;
+    }
+    uint64_t subs = r_msg2_main(view, "subviews", 0, 0, 0, 0);
+    uint64_t count = r_is_objc_ptr(subs) ? r_msg2_main(subs, "count", 0, 0, 0, 0) : 0;
+    if (count > 256) count = 256;
+    for (uint64_t i = 0; i < count; i++)
+        lockcustomizer_scan(r_msg2_main(subs, "objectAtIndex:", i, 0, 0, 0), depth + 1, lockContext, restore, changed);
+}
+
+void lockcustomizer_configure(int clockScalePercent, int horizontalOffset, int verticalOffset,
+                              bool hideQuickActions, bool hidePageDots, int contentAlphaPercent)
+{
+    if (clockScalePercent < 50) clockScalePercent = 50;
+    if (clockScalePercent > 180) clockScalePercent = 180;
+    if (horizontalOffset < -160) horizontalOffset = -160;
+    if (horizontalOffset > 160) horizontalOffset = 160;
+    if (verticalOffset < -300) verticalOffset = -300;
+    if (verticalOffset > 300) verticalOffset = 300;
+    if (contentAlphaPercent < 20) contentAlphaPercent = 20;
+    if (contentAlphaPercent > 100) contentAlphaPercent = 100;
+    gLockClockScale = clockScalePercent;
+    gLockXOffset = horizontalOffset;
+    gLockYOffset = verticalOffset;
+    gLockHideQuickActions = hideQuickActions;
+    gLockHideDots = hidePageDots;
+    gLockContentAlpha = contentAlphaPercent;
+}
+
+static bool lockcustomizer_run(bool restore)
+{
+    uint64_t windows[64] = {0};
+    int windowCount = sb_collect_windows(windows, 64), changed = 0;
+    for (int i = 0; i < windowCount; i++) lockcustomizer_scan(windows[i], 0, false, restore, &changed);
+    printf("[LOCKCUSTOM] restore=%d scale=%d%% x=%d y=%d quick=%d dots=%d alpha=%d%% changed=%d\n",
+           restore, gLockClockScale, gLockXOffset, gLockYOffset,
+           gLockHideQuickActions, gLockHideDots, gLockContentAlpha, changed);
+    return changed > 0;
+}
+
+bool lockcustomizer_apply_in_session(void) { return lockcustomizer_run(false); }
+bool lockcustomizer_stop_in_session(void) { lockcustomizer_run(true); return true; }
+void lockcustomizer_forget_remote_state(void) {}

--- a/Infern0/tweaks/experimental_tweaks.h
+++ b/Infern0/tweaks/experimental_tweaks.h
@@ -43,6 +43,7 @@
 #import "experimental/cylinderlite.h"
 #import "experimental/barmoji.h"
 #import "experimental/iconstyles.h"
+#import "experimental/customizers.h"
 #import "experimental/blurrybadges.h"
 #import "experimental/snapper.h"
 #import "experimental/pullover.h"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ set intentionally modifies persistent files and is clearly marked in the app.
 
 | Area | Highlights |
 | --- | --- |
-| **Home Screen** | SBCustomizer, Gravity Lite, Cylinder Lite, Rounded Icons, Watch Layout, labels, badges, themes, and layout controls |
+| **Home Screen** | SBCustomizer with Atria Lite controls, Gravity Lite, Cylinder Lite, Rounded Icons, Watch Layout, Free Placement Lite, Badge Studio, themes, and layout controls |
+| **Lock Screen** | Lock Screen Customizer for clock placement, scale, opacity, quick actions, and page dots |
 | **Status Bar** | StatBar, NSBar, NiceBar Lite, Signal Readouts, carrier text, and live system information |
 | **Control Center** | Layout, spacing, appearance, status, haptics, and security experiments |
 | **Theming** | Cyanide Themer, SnowBoard Lite imports, icon styles, and LiveWP |
@@ -66,6 +67,12 @@ set intentionally modifies persistent files and is clearly marked in the app.
   Home Screen icon without requiring a theme.
 - **Watch Layout** creates a compact Apple Watch-style grid with circular,
   pressable icons and reversible layout changes.
+- **Free Placement Lite** adds configurable staggered icon offsets while keeping
+  every live icon pressable and restoring saved stock frames on uninstall.
+- **Badge Studio** combines BlurryBadges tinting with notification-count-based
+  Growing Badges+ scaling.
+- **Lock Screen Customizer** moves and scales the live clock and can hide quick
+  actions or page dots, with stock-state cleanup and detailed activity logs.
 - **Gravity Lite** runs physics on live icon views across discovered pages so
   icons remain interactive.
 - **Cylinder Lite** applies perspective depth across the Home Screen while


### PR DESCRIPTION
## What changed

- Added Atria Lite appearance controls to SBCustomizer and independent Home/Dock groups to Home Layout Extras.
- Added configurable Lock Screen Customizer and Free Placement Lite packages.
- Upgraded BlurryBadges into Badge Studio with notification-count-based Growing Badges+ scaling.
- Wired defaults, live refresh, cleanup/restoration, package settings, detailed activity logs, and README documentation.

## Why

These ports expand infern0's configurable SpringBoard customization while keeping live icon interaction intact and ensuring session changes can be restored cleanly.

## Impact

Users get additional Home Screen and Lock Screen customization controls. Free Placement Lite intentionally provides configurable global offsets rather than per-icon dragging in this first RemoteCall implementation.

## Validation

- `git diff --check`
- Structural declaration, settings-key, package-catalog, and lifecycle wiring checks
- Reviewed cleanup ordering for Free Placement Lite and Watch Layout

An Xcode/iOS compile was not available in the Windows workspace and should run in GitHub Actions.
